### PR TITLE
docs: add next race screen specification

### DIFF
--- a/docs/screens/next-race.md
+++ b/docs/screens/next-race.md
@@ -1,0 +1,23 @@
+# Behavior
+
+Displays the upcoming race session.
+
+Read-only screen.
+Receives real-time updates from the server.
+
+# Communication from server to client
+
+- next_session
+
+## Payload
+
+- sessionId
+- drivers[] (name)
+- cars[] (number)
+- status (string)
+
+# Communication from client to server
+
+- connect (Socket.IO)
+
+No other events are sent from this screen.


### PR DESCRIPTION
Adds technical documentation for the Next Race screen.

## Includes
- Behavior definition
- Server to client communication
- Client to server communication
- Payload structure

## Purpose
Defines how the Next Race screen receives and displays real-time session data.

This is a read-only screen that listens to server updates and renders:
- upcoming drivers
- assigned cars
- session status

Keeps the implementation aligned across frontend and backend.