### PR TITLE
docs: add lap line tracker screen specification

### DIFF
--- a/docs/screens/lap-line-tracker.md
+++ b/docs/screens/lap-line-tracker.md
@@ -1,0 +1,42 @@
+# Behavior
+
+Used to record laps for each car.
+
+Displays one button per car in the current session.
+
+Buttons:
+- active during race and finish mode
+- disabled after session ends
+
+Requires authentication before usage.
+
+# Communication from server to client
+
+- auth_request
+- auth_response
+
+- session_state
+
+## Payload
+
+- sessionId
+- cars[] (number)
+- mode (SAFE | HAZARD | DANGER | FINISH)
+- sessionEnded (boolean)
+
+# Communication from client to server
+
+- auth
+
+## Payload
+
+- accessKey
+
+---
+
+- lap
+
+## Payload
+
+- car (number)
+- timestamp (optional)


### PR DESCRIPTION
Adds technical documentation for the Lap-line Tracker screen.

## Includes
- Behavior definition
- Server to client communication
- Client to server communication
- Payload structure

## Purpose
Defines how laps are recorded during a race session.

The Lap-line Tracker allows the observer to:
- record laps by pressing car buttons
- send lap events to the server in real time

Ensures consistent event flow between client and server for lap tracking.