### PR TITLE
docs: Add front desk behavior and event specification

### DIFF
--- a/front-desk.md
+++ b/front-desk.md
@@ -29,5 +29,5 @@ This interface requires an access key before the real-time connection is establi
 - **`session:create`** receptionist adds a new race session. No payload required beyond a session identifier
 - **`session:remove`** receptionist deletes an upcoming session. Payload: `{ sessionId }`
 - **`driver:add`** adds a driver to a session. Payload: `{ sessionId, driverName }`. Server assigns the car number automatically
-- **`driver:edit`** updates a driver's name. Payload: `{ sessionId, driverId, newName }`
-- **`driver:remove`** removes a driver from a session. Payload: `{ sessionId, driverId }`
+- **`driver:edit`** updates a driver's name. Payload: `{ sessionId, driverName, newName }`
+- **`driver:remove`** removes a driver from a session. Payload: `{ sessionId, driverName }`


### PR DESCRIPTION
### Summary
This PR adds documentation for the authenticated front desk interface used by reception staff.

### What is included

- Defines front desk behavior and business rules for upcoming sessions
- Documents authentication expectations before real-time connection use
- Specifies server-to-client Socket.IO events
- Specifies client-to-server messages and payload formats for session and driver management

### Why
This clarifies frontend/backend contract details and reduces ambiguity during implementation.

### Scope

Documentation only
No runtime logic changes