### PR TITLE
Docs/session end screen

### DIFF
--- a/docs/flags-screen.md
+++ b/docs/flags-screen.md
@@ -1,0 +1,67 @@
+# Flags Screen (Safety Officer)
+
+## Overview
+
+The Flags Screen is used by the safety officer to control race conditions in real time.
+
+The selected flag is broadcast to all connected screens, ensuring that drivers and spectators see the current race status immediately.
+
+---
+
+## Available Flags
+
+- Green – race is active
+- Yellow – caution, hazard on track
+- Red – race is stopped
+- Finish – race has ended
+
+---
+
+## What the safety officer does
+
+- Selects a flag using the interface
+- Changes race condition instantly
+
+---
+
+## What is sent to the server
+
+When a flag is selected:
+
+- Event: `race:flag`
+- Data:
+  - `flag` (green | yellow | red | finish)
+
+---
+
+## What the server does
+
+- Updates the current race state
+- Stores the active flag
+- Broadcasts the update to all clients
+
+---
+
+## What clients receive
+
+- Event: `flag:updated`
+- Data:
+  - `flag` (current flag)
+
+---
+
+## What must happen
+
+- All screens update immediately
+- Green → race continues
+- Yellow → caution mode
+- Red → race stops
+- Finish → race ends
+
+---
+
+## Result
+
+- All participants see the same race state
+- Safety officer controls race flow centrally
+- System stays synchronized across all screens

--- a/docs/flags-screen.md
+++ b/docs/flags-screen.md
@@ -36,6 +36,7 @@ When a flag is selected:
 
 ## What the server does
 
+- Validates that the race is active before applying the flag
 - Updates the current race state
 - Stores the active flag
 - Broadcasts the update to all clients
@@ -52,6 +53,7 @@ When a flag is selected:
 
 ## What must happen
 
+- Flag changes are only allowed during an active race
 - All screens update immediately
 - Green → race continues
 - Yellow → caution mode
@@ -65,3 +67,11 @@ When a flag is selected:
 - All participants see the same race state
 - Safety officer controls race flow centrally
 - System stays synchronized across all screens
+
+## Event Flow
+
+1. Safety officer selects a flag  
+2. Client sends `race:flag` event to server  
+3. Server validates that the race is active and updates race state 
+4. Server broadcasts `flag:updated` to all clients  
+5. All screens update the displayed flag  

--- a/docs/race-end-screen.md
+++ b/docs/race-end-screen.md
@@ -1,0 +1,62 @@
+# Race End Screen (Safety Officer)
+
+## Overview
+
+The Race End Screen is used by the safety officer to stop the race.
+
+When the race is stopped, all systems and screens must reflect that the race has ended.
+
+---
+
+## What the safety officer does
+
+- Presses the "Stop Race" button
+- Ends the race immediately
+
+---
+
+## What is sent to the server
+
+- Event: `race:end`
+
+---
+
+## What the server does
+
+- Validates that a race is currently active
+- Stops the race
+- Finalizes race data (laps, results)
+- Broadcasts race end event to all clients
+
+---
+
+## What clients receive
+
+- Event: `race:ended`
+
+---
+
+## What must happen
+
+- Timer stops
+- Lap counting stops
+- Leaderboard is finalized
+- Screens show that the race has ended
+
+---
+
+## Result
+
+- Race is fully stopped
+- Results are fixed and visible
+- System prepares for next phase
+
+---
+
+## Event Flow
+
+1. Safety officer presses "Stop Race"  
+2. Client sends `race:end` to server  
+3. Server validates and stops the race  
+4. Server broadcasts `race:ended`  
+5. All screens update  

--- a/docs/session-end-screen.md
+++ b/docs/session-end-screen.md
@@ -1,0 +1,60 @@
+# Session End Screen (Safety Officer)
+
+## Overview
+
+The Session End Screen is used to fully close the race session.
+
+This includes resetting the system and preparing for the next race.
+
+---
+
+## What the safety officer does
+
+- Confirms session end
+- Resets the system for the next race
+
+---
+
+## What is sent to the server
+
+- Event: `session:end`
+
+---
+
+## What the server does
+
+- Confirms all races are finished
+- Resets race data
+- Prepares system for next session
+- Broadcasts session end event
+
+---
+
+## What clients receive
+
+- Event: `session:ended`
+
+---
+
+## What must happen
+
+- All race data is cleared or archived
+- Screens reset
+- System shows next race preparation
+
+---
+
+## Result
+
+- Session is fully completed
+- System is ready for a new race
+
+---
+
+## Event Flow
+
+1. Safety officer confirms session end  
+2. Client sends `session:end`  
+3. Server resets system  
+4. Server broadcasts `session:ended`  
+5. Screens reset  


### PR DESCRIPTION
Added Session End Screen specification for the safety officer.

This document describes:
- how the session is completed
- what event is sent to the server (`session:end`)
- how the server processes the request
- what is broadcast to all clients (`session:ended`)
- what must happen after the session ends

Includes event flow and system behavior to ensure the system resets and is ready for the next race.