### PR TITLE
feat: add race control frontend socket logic

### DIFF
--- a/frontend/app/package-lock.json
+++ b/frontend/app/package-lock.json
@@ -15,6 +15,7 @@
         "@angular/platform-browser": "^21.2.0",
         "@angular/router": "^21.2.0",
         "rxjs": "~7.8.0",
+        "socket.io-client": "^4.8.3",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -3840,6 +3841,12 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -4789,7 +4796,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4934,6 +4940,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/entities": {
@@ -6382,7 +6410,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/msgpackr": {
@@ -7635,6 +7662,34 @@
         "npm": ">= 3.0.0"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/socks": {
       "version": "2.8.7",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
@@ -8430,6 +8485,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -8446,6 +8522,14 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -18,6 +18,7 @@
     "@angular/platform-browser": "^21.2.0",
     "@angular/router": "^21.2.0",
     "rxjs": "~7.8.0",
+    "socket.io-client": "^4.8.3",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/frontend/app/src/app/app.routes.ts
+++ b/frontend/app/src/app/app.routes.ts
@@ -1,6 +1,6 @@
 import { Routes } from '@angular/router';
 import { FrontDesk } from './screens/front-desk/front-desk';
-import { RaceControl } from './screens/race-control/race-control';
+import { RaceControl  } from './screens/race-control/race-control';
 import { LapLineTracker } from './screens/lap-line-tracker/lap-line-tracker';
 import { LeaderBoard } from './screens/leader-board/leader-board';
 import { NextRace } from './screens/next-race/next-race';

--- a/frontend/app/src/app/screens/race-control/race-control.ts
+++ b/frontend/app/src/app/screens/race-control/race-control.ts
@@ -19,8 +19,9 @@ export class RaceControl implements OnInit, OnDestroy {
   sessionStatus: SessionStatus = 'notStarted';
   currentFlag: RaceFlag | '' = '';
   message = '';
-
-   // Temporary until proper UI for entering the key is added
+  
+  // Temporary until proper UI for entering the key is added
+   // Planned approach: provide the key via a UI prompt or shared config once the unified HTML/SCSS screens are implemented.
   accessKey = 'test-key';
 
   ngOnInit(): void {
@@ -79,7 +80,7 @@ export class RaceControl implements OnInit, OnDestroy {
   }
 
   canEndSession(): boolean {
-    return this.connected && this.sessionStatus === 'finished';
+    return this.connected && this.sessionStatus !== 'notStarted';
   }
 
 ngOnDestroy(): void {

--- a/frontend/app/src/app/screens/race-control/race-control.ts
+++ b/frontend/app/src/app/screens/race-control/race-control.ts
@@ -20,21 +20,28 @@ export class RaceControl implements OnInit, OnDestroy {
   currentFlag: RaceFlag | '' = '';
   message = '';
 
-  ngOnInit() {
+   // Temporary until proper UI for entering the key is added
+  accessKey = 'test-key';
+
+  ngOnInit(): void {
     this.socket = io();
 
     this.socket.on('connect', () => {
-      this.connected = true;
-      this.message = 'Ühendus loodud';
-
-      this.socket.emit('selectRoom', { room: 'race-control' }, (response: { status: string }) => {
-        this.message = response?.status ?? 'Room valitud';
-      });
-    });
-
+      this.socket.emit('selectRoom', { room: 'race-control', key: this.accessKey },
+      (response: { status: string }) => {
+        if (response.status === 'Success') {
+          this.connected = true;
+          this.message = 'Connected';
+        } else {
+          this.connected = false;
+          this.message = response?.status ?? 'Connection failed';
+      }
+     }
+    );
+  });
     this.socket.on('disconnect', () => {
       this.connected = false;
-      this.message = 'Ühendus katkes';
+      this.message = 'Connection lost';
     });
 
     this.socket.on('sessionStatus', (args: { status: SessionStatus }) => {
@@ -48,19 +55,19 @@ export class RaceControl implements OnInit, OnDestroy {
 
   startRaceCountdown(): void {
     this.socket.emit('raceStartCountdown', {}, (response: { status: string }) => {
-      this.message = response?.status ?? 'Käsk saadetud';
+      this.message = response?.status ?? 'Command sent';
     });
   }
 
   changeFlag(flag: RaceFlag): void {
     this.socket.emit('raceFlag', { flag }, (response: { status: string }) => {
-      this.message = response?.status ?? 'Lipp muudetud';
+      this.message = response?.status ?? 'Flag updated';
     });
   }
 
   endSession(): void {
     this.socket.emit('sessionEnd', {});
-    this.message = 'Sessiooni lõpetamise käsk saadetud';
+    this.message = 'Session end command sent';
   }
 
   canStartRace(): boolean {
@@ -72,7 +79,7 @@ export class RaceControl implements OnInit, OnDestroy {
   }
 
   canEndSession(): boolean {
-    return this.connected && this.sessionStatus !== 'notStarted';
+    return this.connected && this.sessionStatus === 'finished';
   }
 
 ngOnDestroy(): void {

--- a/frontend/app/src/app/screens/race-control/race-control.ts
+++ b/frontend/app/src/app/screens/race-control/race-control.ts
@@ -1,9 +1,83 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { io, Socket } from 'socket.io-client';
+
+type SessionStatus = 'notStarted' | 'active' | 'finished';
+type RaceFlag = 'green' | 'yellow' | 'red' | 'finish';
 
 @Component({
   selector: 'app-race-control',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './race-control.html',
-  styleUrl: './race-control.scss',
+  styleUrls: ['./race-control.scss'],
 })
-export class RaceControl {}
+export class RaceControl implements OnInit, OnDestroy {
+  private socket!: Socket;
+
+  connected = false;
+  sessionStatus: SessionStatus = 'notStarted';
+  currentFlag: RaceFlag | '' = '';
+  message = '';
+
+  ngOnInit() {
+    this.socket = io();
+
+    this.socket.on('connect', () => {
+      this.connected = true;
+      this.message = 'Ühendus loodud';
+
+      this.socket.emit('selectRoom', { room: 'race-control' }, (response: { status: string }) => {
+        this.message = response?.status ?? 'Room valitud';
+      });
+    });
+
+    this.socket.on('disconnect', () => {
+      this.connected = false;
+      this.message = 'Ühendus katkes';
+    });
+
+    this.socket.on('sessionStatus', (args: { status: SessionStatus }) => {
+      this.sessionStatus = args.status;
+    });
+
+    this.socket.on('flagChanged', (args: { flag: RaceFlag }) => {
+      this.currentFlag = args.flag;
+    });
+  }
+
+  startRaceCountdown(): void {
+    this.socket.emit('raceStartCountdown', {}, (response: { status: string }) => {
+      this.message = response?.status ?? 'Käsk saadetud';
+    });
+  }
+
+  changeFlag(flag: RaceFlag): void {
+    this.socket.emit('raceFlag', { flag }, (response: { status: string }) => {
+      this.message = response?.status ?? 'Lipp muudetud';
+    });
+  }
+
+  endSession(): void {
+    this.socket.emit('sessionEnd', {});
+    this.message = 'Sessiooni lõpetamise käsk saadetud';
+  }
+
+  canStartRace(): boolean {
+    return this.connected && this.sessionStatus === 'notStarted';
+  }
+
+  canUseFlags(): boolean {
+    return this.connected && this.sessionStatus === 'active';
+  }
+
+  canEndSession(): boolean {
+    return this.connected && this.sessionStatus !== 'notStarted';
+  }
+
+ngOnDestroy(): void {
+  if (this.socket) {
+    this.socket.disconnect();
+    }
+  }
+}


### PR DESCRIPTION
What was done
- Added race-control (safety officer) frontend logic
- Added socket.io connection
- Added event listeners (sessionStatus, flagChanged)
- Added commands:
  - raceStartCountdown
  - raceFlag
  - sessionEnd

 Notes
- This PR includes only TypeScript logic
- HTML and SCSS will be added in the next step

Testing
- Verified that the `/race-control` route loads successfully
- Verified that the Race Control component is displayed in the browser
- Frontend starts without errors