### PR TITLE
Add race flags screen frontend logic

### DIFF
--- a/frontend/app/src/app/screens/race-flags/race-flags.ts
+++ b/frontend/app/src/app/screens/race-flags/race-flags.ts
@@ -1,9 +1,48 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { io, Socket } from 'socket.io-client';
+
+type RaceFlag = 'green' | 'yellow' | 'red' | 'finish';
 
 @Component({
   selector: 'app-race-flags',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './race-flags.html',
-  styleUrl: './race-flags.scss',
+  styleUrls: ['./race-flags.scss'],
 })
-export class RaceFlags {}
+export class RaceFlags implements OnInit, OnDestroy {
+  private socket!: Socket;
+
+  connected = false;
+  currentFlag: RaceFlag | '' = '';
+  message = '';
+
+  ngOnInit(): void {
+    this.socket = io();
+
+    this.socket.on('connect', () => {
+      this.connected = true;
+      this.message = 'Connected';
+
+      this.socket.emit('selectRoom', { room: 'race-flags' }, (response: { status: string }) => {
+        this.message = response?.status ?? 'Room selected';
+      });
+    });
+
+    this.socket.on('disconnect', () => {
+      this.connected = false;
+      this.message = 'Connection lost';
+    });
+
+    this.socket.on('flagChanged', (args: { flag: RaceFlag }) => {
+      this.currentFlag = args.flag;
+    });
+  }
+
+  ngOnDestroy(): void {
+    if (this.socket) {
+      this.socket.disconnect();
+    }
+  }
+}


### PR DESCRIPTION
Overview
Implemented the Race Flags screen frontend logic and basic HTML structure.

 What was done
- Created RaceFlags standalone Angular component
- Added basic HTML structure for displaying connection status and current flag
- Established Socket.IO connection on component init
- Joined `race-flags` room
- Listens for `flagChanged` events
- Updates current flag state in real-time
- Handles connection and disconnection states

Note
UI (HTML and SCSS) will be implemented in a separate step together for all screens to ensure consistency across the application.