### PR TITLE
Implement finish race flow in race control frontend

### DIFF
--- a/frontend/app/src/app/screens/race-control/race-control.ts
+++ b/frontend/app/src/app/screens/race-control/race-control.ts
@@ -20,10 +20,10 @@ export class RaceControl implements OnInit, OnDestroy {
   currentFlag: RaceFlag | '' = '';
   message = '';
 
-   // Temporary until proper UI for entering the key is added
-  accessKey = 'test-key';
+  accessKey = '';
 
   ngOnInit(): void {
+    this.accessKey = prompt('Enter access key') ?? '';
     this.socket = io();
 
     this.socket.on('connect', () => {
@@ -94,7 +94,7 @@ export class RaceControl implements OnInit, OnDestroy {
   }
 
   canEndSession(): boolean {
-    return this.connected && this.sessionStatus === 'finished';
+    return this.connected && this.sessionStatus !== 'notStarted';
   }
 
 ngOnDestroy(): void {

--- a/frontend/app/src/app/screens/race-control/race-control.ts
+++ b/frontend/app/src/app/screens/race-control/race-control.ts
@@ -1,9 +1,91 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { io, Socket } from 'socket.io-client';
+
+type SessionStatus = 'notStarted' | 'active' | 'finished';
+type RaceFlag = 'green' | 'yellow' | 'red' | 'finish';
 
 @Component({
   selector: 'app-race-control',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './race-control.html',
-  styleUrl: './race-control.scss',
+  styleUrls: ['./race-control.scss'],
 })
-export class RaceControl {}
+export class RaceControl implements OnInit, OnDestroy {
+  private socket!: Socket;
+
+  connected = false;
+  sessionStatus: SessionStatus = 'notStarted';
+  currentFlag: RaceFlag | '' = '';
+  message = '';
+
+  ngOnInit(): void {
+    this.socket = io();
+
+    this.socket.on('connect', () => {
+      this.connected = true;
+      this.message = 'Ühendus loodud';
+
+      this.socket.emit('selectRoom', { room: 'race-control' }, (response: { status: string }) => {
+        this.message = response?.status ?? 'Room valitud';
+      });
+    });
+
+    this.socket.on('disconnect', () => {
+      this.connected = false;
+      this.message = 'Ühendus katkes';
+    });
+
+    this.socket.on('sessionStatus', (args: { status: SessionStatus }) => {
+      this.sessionStatus = args.status;
+    });
+
+    this.socket.on('flagChanged', (args: { flag: RaceFlag }) => {
+      this.currentFlag = args.flag;
+    });
+  }
+
+  startRaceCountdown(): void {
+    this.socket.emit('raceStartCountdown', {}, (response: { status: string }) => {
+      this.message = response?.status ?? 'Käsk saadetud';
+    });
+  }
+
+  changeFlag(flag: RaceFlag): void {
+    this.socket.emit('raceFlag', { flag }, (response: { status: string }) => {
+      this.message = response?.status ?? 'Lipp muudetud';
+    });
+  }
+
+  finishRace(): void {
+    this.changeFlag('finish');
+  }
+
+  endSession(): void {
+    this.socket.emit('sessionEnd', {});
+    this.message = 'Sessiooni lõpetamise käsk saadetud';
+  }
+
+  canStartRace(): boolean {
+    return this.connected && this.sessionStatus === 'notStarted';
+  }
+
+  canUseFlags(): boolean {
+    return this.connected && this.sessionStatus === 'active';
+  }
+
+  canFinishRace(): boolean {
+    return this.connected && this.sessionStatus === 'active';
+  }
+
+  canEndSession(): boolean {
+    return this.connected && this.sessionStatus !== 'notStarted';
+  }
+
+  ngOnDestroy(): void {
+    if (this.socket) {
+      this.socket.disconnect();
+    }
+  }
+}

--- a/frontend/app/src/app/screens/race-control/race-control.ts
+++ b/frontend/app/src/app/screens/race-control/race-control.ts
@@ -20,21 +20,31 @@ export class RaceControl implements OnInit, OnDestroy {
   currentFlag: RaceFlag | '' = '';
   message = '';
 
+   // Temporary until proper UI for entering the key is added
+  accessKey = 'test-key';
+
   ngOnInit(): void {
     this.socket = io();
 
     this.socket.on('connect', () => {
-      this.connected = true;
-      this.message = 'Ühendus loodud';
-
-      this.socket.emit('selectRoom', { room: 'race-control' }, (response: { status: string }) => {
-        this.message = response?.status ?? 'Room valitud';
-      });
-    });
-
+      this.socket.emit('selectRoom', { room: 'race-control', key: this.accessKey },
+      (response: { status: string }) => {
+        if (response.status === 'Success') {
+          this.connected = true;
+          this.message = 'Connected';
+        } else if (response.status === 'Invalid Access Key') {
+          this.connected = false;
+          this.message = 'Invalid Access Key';
+        } else {
+          this.connected = false;
+          this.message = response?.status ?? 'Connection failed';
+      }
+     }
+    );
+  });
     this.socket.on('disconnect', () => {
       this.connected = false;
-      this.message = 'Ühendus katkes';
+      this.message = 'Connection lost';
     });
 
     this.socket.on('sessionStatus', (args: { status: SessionStatus }) => {
@@ -47,24 +57,32 @@ export class RaceControl implements OnInit, OnDestroy {
   }
 
   startRaceCountdown(): void {
+    if (!this.socket || !this.connected) {
+    this.message = 'Not connected';
+    return;
+  }
     this.socket.emit('raceStartCountdown', {}, (response: { status: string }) => {
-      this.message = response?.status ?? 'Käsk saadetud';
+      this.message = response?.status ?? 'Command sent';
     });
   }
 
   changeFlag(flag: RaceFlag): void {
+    if (!this.socket || !this.connected) {
+    this.message = 'Not connected';
+    return;
+  }
     this.socket.emit('raceFlag', { flag }, (response: { status: string }) => {
-      this.message = response?.status ?? 'Lipp muudetud';
+      this.message = response?.status ?? 'Flag updated';
     });
   }
 
-  finishRace(): void {
-    this.changeFlag('finish');
-  }
-
   endSession(): void {
+    if (!this.socket || !this.connected) {
+    this.message = 'Not connected';
+    return;
+  }
     this.socket.emit('sessionEnd', {});
-    this.message = 'Sessiooni lõpetamise käsk saadetud';
+    this.message = 'Session end command sent';
   }
 
   canStartRace(): boolean {
@@ -75,17 +93,13 @@ export class RaceControl implements OnInit, OnDestroy {
     return this.connected && this.sessionStatus === 'active';
   }
 
-  canFinishRace(): boolean {
-    return this.connected && this.sessionStatus === 'active';
-  }
-
   canEndSession(): boolean {
-    return this.connected && this.sessionStatus !== 'notStarted';
+    return this.connected && this.sessionStatus === 'finished';
   }
 
-  ngOnDestroy(): void {
-    if (this.socket) {
-      this.socket.disconnect();
+ngOnDestroy(): void {
+  if (this.socket) {
+    this.socket.disconnect();
     }
   }
 }


### PR DESCRIPTION
Overview
Implemented finish race flow in race control frontend.

Allows the safety officer to trigger race finish by setting the flag to chequered.

What was done
- Added finish race functionality to RaceControl component
- Sends `raceFlag` event with value `finish`
- Reuses existing flag change logic
- Integrated with Socket.IO communication

 Note
HTML and SCSS will be implemented later together for all screens as a unified UI.