### PR TITLE
feat(be): implement race flag control event

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -38,14 +38,6 @@ if (!("NODE_ENV" in env)) {
 
 const repository = new Repository(raceDuration);
 
-function broadcastRaceState() {
-    io.to("race-control").emit("raceStateUpdate", repository.currentRace);
-    io.to("leader-board").emit("raceStateUpdate", repository.currentRace);
-    io.to("race-countdown").emit("raceStateUpdate", repository.currentRace);
-    io.to("race-flags").emit("raceStateUpdate", repository.currentRace);
-    io.to("next-race").emit("raceStateUpdate", repository.currentRace);
-}
-
 io.on('connection', (socket) => {
     socket.on("selectRoom", (args, callback) => {
         if (publicRooms.includes(args.room)) {
@@ -67,26 +59,6 @@ io.on('connection', (socket) => {
         }
     });
 
-    socket.on("startRace", (callback) => {
-        if (!socket.rooms.has("race-control")) {
-            callback({
-                status: "Error",
-                message: "Unauthorized"
-            });
-            return;
-        }
-
-        const result = repository.startRace();
-
-        if (result.status !== "Success") {
-            callback(result);
-            return;
-        }
-
-        broadcastRaceState();
-        callback({ status: "Success" });
-    });
-
     socket.on("raceFlag", (args, callback) => {
         if (!socket.rooms.has("race-control")) {
             callback({ status: "Race not Active" });
@@ -100,7 +72,12 @@ io.on('connection', (socket) => {
             return;
         }
 
-        broadcastRaceState();
+        io.to("race-control")
+            .to("leader-board")
+            .to("race-countdown")
+            .to("race-flags")
+            .to("next-race")
+            .emit("raceStateUpdate", repository.currentRace);
         callback({ status: "Success" });
     });
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -87,6 +87,26 @@ io.on('connection', (socket) => {
         callback({ status: "Success" });
     });
 
+    socket.on("setFlag", (args, callback) => {
+        if (!socket.rooms.has("race-control")) {
+            callback({
+                status: "Error",
+                message: "Unauthorized"
+            });
+            return;
+        }
+
+        const result = repository.setFlag(args.flag);
+
+        if (result.status !== "Success") {
+            callback(result);
+            return;
+        }
+
+        broadcastRaceState();
+        callback({ status: "Success" });
+    });
+
     // Event listeners as modules can be added here
 });
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -87,19 +87,16 @@ io.on('connection', (socket) => {
         callback({ status: "Success" });
     });
 
-    socket.on("setFlag", (args, callback) => {
+    socket.on("raceFlag", (args, callback) => {
         if (!socket.rooms.has("race-control")) {
-            callback({
-                status: "Error",
-                message: "Unauthorized"
-            });
+            callback({ status: "Race not Active" });
             return;
         }
 
         const result = repository.setFlag(args.flag);
 
-        if (result.status !== "Success") {
-            callback(result);
+        if (result !== "Success") {
+            callback({ status: result });
             return;
         }
 

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -65,6 +65,31 @@ class Repository {
         };
     }
 
+    setFlag(flag) {
+        const allowedFlags = ["green", "yellow", "red", "chequered"];
+
+        if (!allowedFlags.includes(flag)) {
+            return {
+                status: "Error",
+                message: "Invalid flag"
+            };
+        }
+
+        if (this.currentRace.status !== "running") {
+            return {
+                status: "Error",
+                message: "Race not running"
+            };
+        }
+
+        this.currentRace.flag = flag;
+
+        return {
+            status: "Success",
+            race: this.currentRace
+        };
+    }
+
      // addSession, updateSession, addDriver, updateDriver, deleteDriver, etc have to be implemented
  }
 

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -48,23 +48,6 @@ class Repository {
         return "Session not found";
     }
 
-    startRace() {
-        if (this.currentRace.sessionId === null) {
-            return {
-                status: "Error",
-                message: "No session loaded"
-            };
-        }
-        this.currentRace.status = "running";
-        this.currentRace.flag = "green";
-        this.currentRace.remainingSeconds = this.defaultRaceDuration;
-
-        return {
-            status: "Success",
-            race: this.currentRace
-        };
-    }
-
     setFlag(flag) {
         const allowedFlags = ["green", "yellow", "red", "finish"];
 

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -72,7 +72,7 @@ class Repository {
             return "Invalid flag";
         }
 
-        if (this.currentRace.status !== "active") {
+        if (this.currentRace.status !== "running") {
             return "Race not Active";
         }
 

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -66,28 +66,23 @@ class Repository {
     }
 
     setFlag(flag) {
-        const allowedFlags = ["green", "yellow", "red", "chequered"];
+        const allowedFlags = ["green", "yellow", "red", "finish"];
 
         if (!allowedFlags.includes(flag)) {
-            return {
-                status: "Error",
-                message: "Invalid flag"
-            };
+            return "Invalid flag";
         }
 
-        if (this.currentRace.status !== "running") {
-            return {
-                status: "Error",
-                message: "Race not running"
-            };
+        if (this.currentRace.status !== "active") {
+            return "Race not Active";
+        }
+
+        if (this.currentRace.flag === flag) {
+            return "Flag Not Changed";
         }
 
         this.currentRace.flag = flag;
 
-        return {
-            status: "Success",
-            race: this.currentRace
-        };
+        return "Success";
     }
 
      // addSession, updateSession, addDriver, updateDriver, deleteDriver, etc have to be implemented


### PR DESCRIPTION
What
Implements backend support for changing the current race flag from race-control.

Changes
- added setFlag(flag) in repository
- added Socket.IO event setFlag
- validates allowed flag values
- restricts flag changes to an active/running race
- broadcasts updated race state after a successful flag change

Notes
- only race-control can change the flag
- this PR focuses on flag control only
- race state is still broadcast through the shared race state flow

Related
Closes #19