### PR TITLE
feat(be): implement session end event

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -127,24 +127,14 @@ io.on('connection', (socket) => {
         callback({ status: "Success" });
     });
 
-    socket.on("endSession", (callback) => {
+    socket.on("sessionEnd", () => {
         if (!socket.rooms.has("race-control")) {
-            callback({
-                status: "Error",
-                message: "Unauthorized"
-            });
             return;
         }
 
-        const result = repository.endSession();
-
-        if (result.status !== "Success") {
-            callback(result);
-            return;
-        }
+        repository.endSession();
 
         broadcastRaceState();
-        callback({ status: "Success" });
     });
 
     // Event listeners as modules can be added here

--- a/backend/index.js
+++ b/backend/index.js
@@ -127,6 +127,26 @@ io.on('connection', (socket) => {
         callback({ status: "Success" });
     });
 
+    socket.on("endSession", (callback) => {
+        if (!socket.rooms.has("race-control")) {
+            callback({
+                status: "Error",
+                message: "Unauthorized"
+            });
+            return;
+        }
+
+        const result = repository.endSession();
+
+        if (result.status !== "Success") {
+            callback(result);
+            return;
+        }
+
+        broadcastRaceState();
+        callback({ status: "Success" });
+    });
+
     // Event listeners as modules can be added here
 });
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -107,6 +107,26 @@ io.on('connection', (socket) => {
         callback({ status: "Success" });
     });
 
+    socket.on("finishRace", (callback) => {
+        if (!socket.rooms.has("race-control")) {
+            callback({
+                status: "Error",
+                message: "Unauthorized"
+            });
+            return;
+        }
+
+        const result = repository.finishRace();
+
+        if (result.status !== "Success") {
+            callback(result);
+            return;
+        }
+
+        broadcastRaceState();
+        callback({ status: "Success" });
+    });
+
     // Event listeners as modules can be added here
 });
 

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -65,6 +65,30 @@ class Repository {
         };
     }
 
+    finishRace() {
+        if (this.currentRace.sessionId === null) {
+            return {
+                status: "Error",
+                message: "No session loaded"
+            };
+        }
+
+        if (this.currentRace.status !== "running") {
+            return {
+                status: "Error",
+                message: "Race not running"
+            };
+        }
+
+        this.currentRace.status = "finished";
+        this.currentRace.flag = "chequered";
+
+        return {
+            status: "Success",
+            race: this.currentRace
+        };
+    }
+
     setFlag(flag) {
         const allowedFlags = ["green", "yellow", "red", "chequered"];
 

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -98,8 +98,15 @@ class Repository {
             return;
         }
 
-        this.currentRace.status = "notStarted";
-        this.currentRace.flag = "red";
+        this.currentRace = {
+            status: "notStarted",
+            sessionId: null,
+            carNumbers: null,
+            completedLaps: null,
+            bestLapTime: null,
+            flag: "red",
+            remainingSeconds: null
+        };
     }
 
     setFlag(flag) {

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -55,7 +55,7 @@ class Repository {
                 message: "No session loaded"
             };
         }
-        this.currentRace.status = "running";
+        this.currentRace.status = "active";
         this.currentRace.flag = "green";
         this.currentRace.remainingSeconds = this.defaultRaceDuration;
 
@@ -73,7 +73,7 @@ class Repository {
             };
         }
 
-        if (this.currentRace.status !== "running") {
+        if (this.currentRace.status !== "active") {
             return {
                 status: "Error",
                 message: "Race not running"
@@ -81,7 +81,7 @@ class Repository {
         }
 
         this.currentRace.status = "finished";
-        this.currentRace.flag = "chequered";
+        this.currentRace.flag = "finish";
 
         return {
             status: "Success",
@@ -91,30 +91,19 @@ class Repository {
 
     endSession() {
         if (this.currentRace.sessionId === null) {
-            return {
-                status: "Error",
-                message: "No session loaded"
-            };
+            return;
         }
 
         if (this.currentRace.status !== "finished") {
-            return {
-                status: "Error",
-                message: "Race not finished"
-            };
+            return;
         }
 
-        this.currentRace.status = "sessionEnded";
+        this.currentRace.status = "notStarted";
         this.currentRace.flag = "red";
-
-        return {
-            status: "Success",
-            race: this.currentRace
-        };
     }
 
     setFlag(flag) {
-        const allowedFlags = ["green", "yellow", "red", "chequered"];
+        const allowedFlags = ["green", "yellow", "red", "finish"];
 
         if (!allowedFlags.includes(flag)) {
             return {
@@ -123,7 +112,7 @@ class Repository {
             };
         }
 
-        if (this.currentRace.status !== "running") {
+        if (this.currentRace.status !== "active") {
             return {
                 status: "Error",
                 message: "Race not running"

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -89,6 +89,30 @@ class Repository {
         };
     }
 
+    endSession() {
+        if (this.currentRace.sessionId === null) {
+            return {
+                status: "Error",
+                message: "No session loaded"
+            };
+        }
+
+        if (this.currentRace.status !== "finished") {
+            return {
+                status: "Error",
+                message: "Race not finished"
+            };
+        }
+
+        this.currentRace.status = "sessionEnded";
+        this.currentRace.flag = "red";
+
+        return {
+            status: "Success",
+            race: this.currentRace
+        };
+    }
+
     setFlag(flag) {
         const allowedFlags = ["green", "yellow", "red", "chequered"];
 


### PR DESCRIPTION
What
Implements backend support for ending a finished session from race-control.

Changes
- added endSession() in repository
- added Socket.IO event endSession
- validates that a session is loaded
- validates that the race is already finished before ending the session
- broadcasts updated race state after a successful session end

Notes
- only race-control can end the session
- this PR adds the event flow and repository method only
- session lifecycle cleanup/reset is intentionally left for follow-up work

Related
Closes #21