### PR TITLE
feat(be): implement next race data flow

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -50,14 +50,10 @@ function broadcastNextSession() {
     const result = repository.getNextSession();
 
     if (result.status !== "Success") {
-        io.to("next-race").emit("nextRaceUpdate", {
-            status: "Error",
-            message: result.message
-        });
         return;
     }
 
-    io.to("next-race").emit("nextRaceUpdate", result.session);
+    io.to("next-race").emit("nextSessionUpdate", result.session);
 }
 
 io.on('connection', (socket) => {
@@ -141,39 +137,15 @@ io.on('connection', (socket) => {
         callback({ status: "Success" });
     });
 
-    socket.on("endSession", (callback) => {
+    socket.on("sessionEnd", () => {
         if (!socket.rooms.has("race-control")) {
-            callback({
-                status: "Error",
-                message: "Unauthorized"
-            });
             return;
         }
 
-        const result = repository.endSession();
-
-        if (result.status !== "Success") {
-            callback(result);
-            return;
-        }
+        repository.endSession();
 
         broadcastRaceState();
         broadcastNextSession();
-        callback({ status: "Success" });
-    });
-
-    socket.on("getNextRace", (callback) => {
-        const result = repository.getNextSession();
-
-        if (result.status !== "Success") {
-            callback(result);
-            return;
-        }
-
-        callback({
-            status: "Success",
-            session: result.session
-        });
     });
 
     // Event listeners as modules can be added here

--- a/backend/index.js
+++ b/backend/index.js
@@ -46,6 +46,20 @@ function broadcastRaceState() {
     io.to("next-race").emit("raceStateUpdate", repository.currentRace);
 }
 
+function broadcastNextSession() {
+    const result = repository.getNextSession();
+
+    if (result.status !== "Success") {
+        io.to("next-race").emit("nextRaceUpdate", {
+            status: "Error",
+            message: result.message
+        });
+        return;
+    }
+
+    io.to("next-race").emit("nextRaceUpdate", result.session);
+}
+
 io.on('connection', (socket) => {
     socket.on("selectRoom", (args, callback) => {
         if (publicRooms.includes(args.room)) {
@@ -144,7 +158,22 @@ io.on('connection', (socket) => {
         }
 
         broadcastRaceState();
+        broadcastNextSession();
         callback({ status: "Success" });
+    });
+
+    socket.on("getNextRace", (callback) => {
+        const result = repository.getNextSession();
+
+        if (result.status !== "Success") {
+            callback(result);
+            return;
+        }
+
+        callback({
+            status: "Success",
+            session: result.session
+        });
     });
 
     // Event listeners as modules can be added here

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -113,6 +113,27 @@ class Repository {
         };
     }
 
+    getNextSession() {
+        if (this.sessions.length === 0) {
+            return {
+                status: "Error",
+                message: "No upcoming sessions"
+            };
+        }
+
+        const nextSession = this.sessions[0];
+
+        return {
+            status: "Success",
+            session: {
+                sessionId: nextSession.sessionId,
+                driverNames: nextSession.driverNames,
+                carNumbers: nextSession.carNumbers,
+                message: "Proceed to paddock"
+            }
+        };
+    }
+
     setFlag(flag) {
         const allowedFlags = ["green", "yellow", "red", "chequered"];
 

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -104,8 +104,15 @@ class Repository {
             };
         }
 
-        this.currentRace.status = "notStarted";
-        this.currentRace.flag = "red";
+        this.currentRace = {
+            status: "notStarted",
+            sessionId: null,
+            carNumbers: null,
+            completedLaps: null,
+            bestLapTime: null,
+            flag: "red",
+            remainingSeconds: null
+        };
 
         return {
             status: "Success",

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -104,7 +104,7 @@ class Repository {
             };
         }
 
-        this.currentRace.status = "sessionEnded";
+        this.currentRace.status = "notStarted";
         this.currentRace.flag = "red";
 
         return {
@@ -128,8 +128,7 @@ class Repository {
             session: {
                 sessionId: nextSession.sessionId,
                 driverNames: nextSession.driverNames,
-                carNumbers: nextSession.carNumbers,
-                message: "Proceed to paddock"
+                carNumbers: nextSession.carNumbers
             }
         };
     }


### PR DESCRIPTION
What
Implements backend support for exposing next-race screen data.

Changes
- added getNextSession() in repository
- added broadcastNextSession() helper
- added Socket.IO event getNextRace
- broadcasts next session data after session end
- returns next session payload with sessionId, driverNames, and carNumbers

Notes
- next session is resolved from the current sessions queue
- returns an error state when no upcoming sessions exist
- keeps next-race screen data separate from the main race state payload

Related
Closes #22