### PR TITLE
feat(be): implement initial flag screen sync

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -65,12 +65,6 @@ io.on('connection', (socket) => {
         if (publicRooms.includes(args.room)) {
             socket.join(args.room);
             callback({status: "Success"});
-
-            if (args.room === "race-flags" && repository.currentRace.status === "active") {
-                socket.emit("flagChanged", {
-                    flag: repository.currentRace.flag
-                });
-            }
         } else if (privateRooms.includes(args.room)) {
             if (args.key === privateRoomKeys[args.room]) {
                 socket.join(args.room);

--- a/backend/index.js
+++ b/backend/index.js
@@ -60,11 +60,22 @@ function broadcastNextSession() {
     io.to("next-race").emit("nextRaceUpdate", result.session);
 }
 
+function emitFlagState(socket) {
+    socket.emit("flagScreenUpdate", {
+        status: repository.currentRace.status,
+        flag: repository.currentRace.flag
+    });
+}
+
 io.on('connection', (socket) => {
     socket.on("selectRoom", (args, callback) => {
         if (publicRooms.includes(args.room)) {
             socket.join(args.room);
             callback({status: "Success"});
+
+            if (args.room === "race-flags") {
+                emitFlagState(socket);
+            }
         } else if (privateRooms.includes(args.room)) {
             if (args.key === privateRoomKeys[args.room]) {
                 socket.join(args.room);
@@ -173,6 +184,16 @@ io.on('connection', (socket) => {
         callback({
             status: "Success",
             session: result.session
+        });
+    });
+
+    socket.on("getFlagScreen", (callback) => {
+        callback({
+            status: "Success",
+            screen: {
+                status: repository.currentRace.status,
+                flag: repository.currentRace.flag
+            }
         });
     });
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -60,21 +60,16 @@ function broadcastNextSession() {
     io.to("next-race").emit("nextRaceUpdate", result.session);
 }
 
-function emitFlagState(socket) {
-    socket.emit("flagScreenUpdate", {
-        status: repository.currentRace.status,
-        flag: repository.currentRace.flag
-    });
-}
-
 io.on('connection', (socket) => {
     socket.on("selectRoom", (args, callback) => {
         if (publicRooms.includes(args.room)) {
             socket.join(args.room);
             callback({status: "Success"});
 
-            if (args.room === "race-flags") {
-                emitFlagState(socket);
+            if (args.room === "race-flags" && repository.currentRace.status === "active") {
+                socket.emit("flagChanged", {
+                    flag: repository.currentRace.flag
+                });
             }
         } else if (privateRooms.includes(args.room)) {
             if (args.key === privateRoomKeys[args.room]) {
@@ -184,16 +179,6 @@ io.on('connection', (socket) => {
         callback({
             status: "Success",
             session: result.session
-        });
-    });
-
-    socket.on("getFlagScreen", (callback) => {
-        callback({
-            status: "Success",
-            screen: {
-                status: repository.currentRace.status,
-                flag: repository.currentRace.flag
-            }
         });
     });
 

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -55,7 +55,7 @@ class Repository {
                 message: "No session loaded"
             };
         }
-        this.currentRace.status = "running";
+        this.currentRace.status = "active";
         this.currentRace.flag = "green";
         this.currentRace.remainingSeconds = this.defaultRaceDuration;
 
@@ -73,7 +73,7 @@ class Repository {
             };
         }
 
-        if (this.currentRace.status !== "running") {
+        if (this.currentRace.status !== "active") {
             return {
                 status: "Error",
                 message: "Race not running"
@@ -81,7 +81,7 @@ class Repository {
         }
 
         this.currentRace.status = "finished";
-        this.currentRace.flag = "chequered";
+        this.currentRace.flag = "finish";
 
         return {
             status: "Success",
@@ -104,7 +104,7 @@ class Repository {
             };
         }
 
-        this.currentRace.status = "sessionEnded";
+        this.currentRace.status = "notStarted";
         this.currentRace.flag = "red";
 
         return {
@@ -135,7 +135,7 @@ class Repository {
     }
 
     setFlag(flag) {
-        const allowedFlags = ["green", "yellow", "red", "chequered"];
+        const allowedFlags = ["green", "yellow", "red", "finish"];
 
         if (!allowedFlags.includes(flag)) {
             return {
@@ -144,7 +144,7 @@ class Repository {
             };
         }
 
-        if (this.currentRace.status !== "running") {
+        if (this.currentRace.status !== "active") {
             return {
                 status: "Error",
                 message: "Race not running"


### PR DESCRIPTION
What
Implements backend support for syncing the flag screen when it joins.

Changes
- sends current flag-related race state when the race-flags room is selected
- keeps the flag screen aligned with the current backend race state on initial connect
- reuses existing race state data instead of introducing separate flag logic

Notes
- this PR focuses on initial flag screen sync only
- live updates still continue through the shared race state broadcast flow
- no race control rules are changed in this PR

Related
Closes #23