### PR TITLE
refactor(be): centralize race state reads in repository

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -38,32 +38,30 @@ if (!("NODE_ENV" in env)) {
 
 const repository = new Repository(raceDuration);
 
-function broadcastRaceState() {
-    const raceState = repository.getRaceState();
+function broadcastSessionStatus() {
+    const sessionStatus = repository.getSessionStatus();
 
-    io.to("race-control").emit("raceStateUpdate", raceState);
-    io.to("leader-board").emit("raceStateUpdate", raceState);
-    io.to("race-countdown").emit("raceStateUpdate", raceState);
-    io.to("race-flags").emit("raceStateUpdate", raceState);
-    io.to("next-race").emit("raceStateUpdate", raceState);
+    io.to("race-control").emit("sessionStatus", sessionStatus);
+    io.to("lap-line-tracker").emit("sessionStatus", sessionStatus);
+    io.to("leader-board").emit("sessionStatus", sessionStatus);
+}
+
+function broadcastFlagChanged() {
+    const flag = repository.getFlag();
+
+    io.to("race-control").emit("flagChanged", flag);
+    io.to("leader-board").emit("flagChanged", flag);
+    io.to("race-flags").emit("flagChanged", flag);
 }
 
 function broadcastNextSession() {
     const result = repository.getNextSession();
 
     if (result.status !== "Success") {
-        io.to("next-race").emit("nextRaceUpdate", {
-            status: "Error",
-            message: result.message
-        });
         return;
     }
 
-    io.to("next-race").emit("nextRaceUpdate", result.session);
-}
-
-function emitFlagState(socket) {
-    socket.emit("flagScreenUpdate", repository.getFlagState());
+    io.to("next-race").emit("nextSessionUpdate", result.session);
 }
 
 io.on('connection', (socket) => {
@@ -72,8 +70,8 @@ io.on('connection', (socket) => {
             socket.join(args.room);
             callback({status: "Success"});
 
-            if (args.room === "race-flags") {
-                emitFlagState(socket);
+            if (args.room === "race-flags" && repository.currentRace.status === "active") {
+                socket.emit("flagChanged", repository.getFlag());
             }
         } else if (privateRooms.includes(args.room)) {
             if (args.key === privateRoomKeys[args.room]) {
@@ -107,7 +105,8 @@ io.on('connection', (socket) => {
             return;
         }
 
-        broadcastRaceState();
+        broadcastSessionStatus();
+        broadcastFlagChanged();
         callback({ status: "Success" });
     });
 
@@ -127,7 +126,7 @@ io.on('connection', (socket) => {
             return;
         }
 
-        broadcastRaceState();
+        broadcastFlagChanged();
         callback({ status: "Success" });
     });
 
@@ -147,7 +146,8 @@ io.on('connection', (socket) => {
             return;
         }
 
-        broadcastRaceState();
+        broadcastSessionStatus();
+        broadcastFlagChanged();
         callback({ status: "Success" });
     });
 
@@ -167,37 +167,10 @@ io.on('connection', (socket) => {
             return;
         }
 
-        broadcastRaceState();
+        broadcastSessionStatus();
+        broadcastFlagChanged();
         broadcastNextSession();
         callback({ status: "Success" });
-    });
-
-    socket.on("getNextRace", (callback) => {
-        const result = repository.getNextSession();
-
-        if (result.status !== "Success") {
-            callback(result);
-            return;
-        }
-
-        callback({
-            status: "Success",
-            session: result.session
-        });
-    });
-
-    socket.on("getFlagScreen", (callback) => {
-        callback({
-            status: "Success",
-            screen: repository.getFlagState()
-        });
-    });
-
-    socket.on("getRaceState", (callback) => {
-        callback({
-            status: "Success",
-            race: repository.getRaceState()
-        });
     });
 
     // Event listeners as modules can be added here

--- a/backend/index.js
+++ b/backend/index.js
@@ -58,6 +58,10 @@ function broadcastNextSession() {
     const result = repository.getNextSession();
 
     if (result.status !== "Success") {
+        io.to("next-race").emit("nextSessionUpdate", {
+            status: "Error",
+            message: result.message
+        });
         return;
     }
 

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -104,8 +104,15 @@ class Repository {
             };
         }
 
-        this.currentRace.status = "notStarted";
-        this.currentRace.flag = "red";
+        this.currentRace = {
+            status: "notStarted",
+            sessionId: null,
+            carNumbers: null,
+            completedLaps: null,
+            bestLapTime: null,
+            flag: "red",
+            remainingSeconds: null
+        };
 
         return {
             status: "Success",

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -55,7 +55,7 @@ class Repository {
                 message: "No session loaded"
             };
         }
-        this.currentRace.status = "running";
+        this.currentRace.status = "active";
         this.currentRace.flag = "green";
         this.currentRace.remainingSeconds = this.defaultRaceDuration;
 
@@ -73,7 +73,7 @@ class Repository {
             };
         }
 
-        if (this.currentRace.status !== "running") {
+        if (this.currentRace.status !== "active") {
             return {
                 status: "Error",
                 message: "Race not running"
@@ -81,7 +81,7 @@ class Repository {
         }
 
         this.currentRace.status = "finished";
-        this.currentRace.flag = "chequered";
+        this.currentRace.flag = "finish";
 
         return {
             status: "Success",
@@ -104,7 +104,7 @@ class Repository {
             };
         }
 
-        this.currentRace.status = "sessionEnded";
+        this.currentRace.status = "notStarted";
         this.currentRace.flag = "red";
 
         return {
@@ -113,21 +113,14 @@ class Repository {
         };
     }
 
-    getRaceState() {
+    getSessionStatus() {
         return {
-            status: this.currentRace.status,
-            sessionId: this.currentRace.sessionId,
-            carNumbers: this.currentRace.carNumbers,
-            completedLaps: this.currentRace.completedLaps,
-            bestLapTime: this.currentRace.bestLapTime,
-            flag: this.currentRace.flag,
-            remainingSeconds: this.currentRace.remainingSeconds
+            status: this.currentRace.status
         };
     }
 
-    getFlagState() {
+    getFlag() {
         return {
-            status: this.currentRace.status,
             flag: this.currentRace.flag
         };
     }
@@ -147,14 +140,13 @@ class Repository {
             session: {
                 sessionId: nextSession.sessionId,
                 driverNames: nextSession.driverNames,
-                carNumbers: nextSession.carNumbers,
-                message: "Proceed to paddock"
+                carNumbers: nextSession.carNumbers
             }
         };
     }
 
     setFlag(flag) {
-        const allowedFlags = ["green", "yellow", "red", "chequered"];
+        const allowedFlags = ["green", "yellow", "red", "finish"];
 
         if (!allowedFlags.includes(flag)) {
             return {
@@ -163,7 +155,7 @@ class Repository {
             };
         }
 
-        if (this.currentRace.status !== "running") {
+        if (this.currentRace.status !== "active") {
             return {
                 status: "Error",
                 message: "Race not running"


### PR DESCRIPTION
What
Refactors backend state access so socket handlers read race state through repository helpers instead of reaching into currentRace directly.

Changes
- added getRaceState() in repository
- added getFlagState() in repository
- updated broadcast helpers to use repository state accessors
- added Socket.IO event getRaceState
- keeps race and flag payload reads consistent across handlers

Notes
- does not introduce new race lifecycle logic
- this is a consistency/refactor PR for backend state access
- intended to make frontend integration and future event cleanup simpler

Related
Closes #24