### PR TITLE
refactor(be): standardize socket event names and response payloads

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -39,11 +39,13 @@ if (!("NODE_ENV" in env)) {
 const repository = new Repository(raceDuration);
 
 function broadcastRaceState() {
-    io.to("race-control").emit("raceStateUpdate", repository.currentRace);
-    io.to("leader-board").emit("raceStateUpdate", repository.currentRace);
-    io.to("race-countdown").emit("raceStateUpdate", repository.currentRace);
-    io.to("race-flags").emit("raceStateUpdate", repository.currentRace);
-    io.to("next-race").emit("raceStateUpdate", repository.currentRace);
+    const raceState = repository.getRaceState();
+
+    io.to("race-control").emit("raceStateUpdate", raceState);
+    io.to("leader-board").emit("raceStateUpdate", raceState);
+    io.to("race-countdown").emit("raceStateUpdate", raceState);
+    io.to("race-flags").emit("raceStateUpdate", raceState);
+    io.to("next-race").emit("raceStateUpdate", raceState);
 }
 
 function broadcastNextSession() {
@@ -61,10 +63,7 @@ function broadcastNextSession() {
 }
 
 function emitFlagState(socket) {
-    socket.emit("flagScreenUpdate", {
-        status: repository.currentRace.status,
-        flag: repository.currentRace.flag
-    });
+    socket.emit("flagScreenUpdate", repository.getFlagState());
 }
 
 io.on('connection', (socket) => {
@@ -190,10 +189,14 @@ io.on('connection', (socket) => {
     socket.on("getFlagScreen", (callback) => {
         callback({
             status: "Success",
-            screen: {
-                status: repository.currentRace.status,
-                flag: repository.currentRace.flag
-            }
+            screen: repository.getFlagState()
+        });
+    });
+
+    socket.on("getRaceState", (callback) => {
+        callback({
+            status: "Success",
+            race: repository.getRaceState()
         });
     });
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -12,6 +12,23 @@ const io = new Server(3000, {
 const publicRooms = ["leader-board", "next-race", "race-countdown", "race-flags"];
 const privateRooms = ["front-desk", "race-control", "lap-line-tracker"];
 
+const clientEvents = {
+    SELECT_ROOM: "selectRoom",
+    START_RACE: "startRace",
+    SET_FLAG: "setFlag",
+    FINISH_RACE: "finishRace",
+    END_SESSION: "endSession",
+    GET_NEXT_RACE: "getNextRace",
+    GET_FLAG_SCREEN: "getFlagScreen",
+    GET_RACE_STATE: "getRaceState"
+};
+
+const serverEvents = {
+    RACE_STATE_UPDATE: "raceStateUpdate",
+    NEXT_RACE_UPDATE: "nextRaceUpdate",
+    FLAG_SCREEN_UPDATE: "flagScreenUpdate"
+};
+
 if (!("receptionist_key" in env) || !("observer_key" in env) || !("safety_key" in env)) {
     console.error("Missing environment variables for private room keys. Please set receptionist_key, observer_key, and safety_key.");
     process.exit(1);
@@ -41,33 +58,33 @@ const repository = new Repository(raceDuration);
 function broadcastRaceState() {
     const raceState = repository.getRaceState();
 
-    io.to("race-control").emit("raceStateUpdate", raceState);
-    io.to("leader-board").emit("raceStateUpdate", raceState);
-    io.to("race-countdown").emit("raceStateUpdate", raceState);
-    io.to("race-flags").emit("raceStateUpdate", raceState);
-    io.to("next-race").emit("raceStateUpdate", raceState);
+    io.to("race-control").emit(serverEvents.RACE_STATE_UPDATE, raceState);
+    io.to("leader-board").emit(serverEvents.RACE_STATE_UPDATE, raceState);
+    io.to("race-countdown").emit(serverEvents.RACE_STATE_UPDATE, raceState);
+    io.to("race-flags").emit(serverEvents.RACE_STATE_UPDATE, raceState);
+    io.to("next-race").emit(serverEvents.RACE_STATE_UPDATE, raceState);
 }
 
 function broadcastNextSession() {
     const result = repository.getNextSession();
 
     if (result.status !== "Success") {
-        io.to("next-race").emit("nextRaceUpdate", {
+        io.to("next-race").emit(serverEvents.NEXT_RACE_UPDATE, {
             status: "Error",
             message: result.message
         });
         return;
     }
 
-    io.to("next-race").emit("nextRaceUpdate", result.session);
+    io.to("next-race").emit(serverEvents.NEXT_RACE_UPDATE, result.session);
 }
 
 function emitFlagState(socket) {
-    socket.emit("flagScreenUpdate", repository.getFlagState());
+    socket.emit(serverEvents.FLAG_SCREEN_UPDATE, repository.getFlagState());
 }
 
 io.on('connection', (socket) => {
-    socket.on("selectRoom", (args, callback) => {
+    socket.on(clientEvents.SELECT_ROOM, (args, callback) => {
         if (publicRooms.includes(args.room)) {
             socket.join(args.room);
             callback({status: "Success"});
@@ -91,7 +108,7 @@ io.on('connection', (socket) => {
         }
     });
 
-    socket.on("startRace", (callback) => {
+    socket.on(clientEvents.START_RACE, (callback) => {
         if (!socket.rooms.has("race-control")) {
             callback({
                 status: "Error",
@@ -111,7 +128,7 @@ io.on('connection', (socket) => {
         callback({ status: "Success" });
     });
 
-    socket.on("setFlag", (args, callback) => {
+    socket.on(clientEvents.SET_FLAG, (args, callback) => {
         if (!socket.rooms.has("race-control")) {
             callback({
                 status: "Error",
@@ -131,7 +148,7 @@ io.on('connection', (socket) => {
         callback({ status: "Success" });
     });
 
-    socket.on("finishRace", (callback) => {
+    socket.on(clientEvents.FINISH_RACE, (callback) => {
         if (!socket.rooms.has("race-control")) {
             callback({
                 status: "Error",
@@ -151,7 +168,7 @@ io.on('connection', (socket) => {
         callback({ status: "Success" });
     });
 
-    socket.on("endSession", (callback) => {
+    socket.on(clientEvents.END_SESSION, (callback) => {
         if (!socket.rooms.has("race-control")) {
             callback({
                 status: "Error",
@@ -172,7 +189,7 @@ io.on('connection', (socket) => {
         callback({ status: "Success" });
     });
 
-    socket.on("getNextRace", (callback) => {
+    socket.on(clientEvents.GET_NEXT_RACE, (callback) => {
         const result = repository.getNextSession();
 
         if (result.status !== "Success") {
@@ -182,21 +199,21 @@ io.on('connection', (socket) => {
 
         callback({
             status: "Success",
-            session: result.session
+            nextSession: result.session
         });
     });
 
-    socket.on("getFlagScreen", (callback) => {
+    socket.on(clientEvents.GET_FLAG_SCREEN, (callback) => {
         callback({
             status: "Success",
-            screen: repository.getFlagState()
+            flagState: repository.getFlagState()
         });
     });
 
-    socket.on("getRaceState", (callback) => {
+    socket.on(clientEvents.GET_RACE_STATE, (callback) => {
         callback({
             status: "Success",
-            race: repository.getRaceState()
+            raceState: repository.getRaceState()
         });
     });
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -19,14 +19,12 @@ const clientEvents = {
     FINISH_RACE: "finishRace",
     END_SESSION: "endSession",
     GET_NEXT_RACE: "getNextRace",
-    GET_FLAG_SCREEN: "getFlagScreen",
     GET_RACE_STATE: "getRaceState"
 };
 
 const serverEvents = {
     RACE_STATE_UPDATE: "raceStateUpdate",
-    NEXT_RACE_UPDATE: "nextRaceUpdate",
-    FLAG_SCREEN_UPDATE: "flagScreenUpdate"
+    NEXT_RACE_UPDATE: "nextRaceUpdate"
 };
 
 if (!("receptionist_key" in env) || !("observer_key" in env) || !("safety_key" in env)) {
@@ -79,19 +77,14 @@ function broadcastNextSession() {
     io.to("next-race").emit(serverEvents.NEXT_RACE_UPDATE, result.session);
 }
 
-function emitFlagState(socket) {
-    socket.emit(serverEvents.FLAG_SCREEN_UPDATE, repository.getFlagState());
-}
-
 io.on('connection', (socket) => {
     socket.on(clientEvents.SELECT_ROOM, (args, callback) => {
         if (publicRooms.includes(args.room)) {
             socket.join(args.room);
             callback({status: "Success"});
 
-            if (args.room === "race-flags") {
-                emitFlagState(socket);
-            }
+            // initial state tuleb läbi raceStateUpdate (FE kuulab seda)
+            socket.emit(serverEvents.RACE_STATE_UPDATE, repository.getRaceState());
         } else if (privateRooms.includes(args.room)) {
             if (args.key === privateRoomKeys[args.room]) {
                 socket.join(args.room);
@@ -200,13 +193,6 @@ io.on('connection', (socket) => {
         callback({
             status: "Success",
             nextSession: result.session
-        });
-    });
-
-    socket.on(clientEvents.GET_FLAG_SCREEN, (callback) => {
-        callback({
-            status: "Success",
-            flagState: repository.getFlagState()
         });
     });
 

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -113,6 +113,25 @@ class Repository {
         };
     }
 
+    getRaceState() {
+        return {
+            status: this.currentRace.status,
+            sessionId: this.currentRace.sessionId,
+            carNumbers: this.currentRace.carNumbers,
+            completedLaps: this.currentRace.completedLaps,
+            bestLapTime: this.currentRace.bestLapTime,
+            flag: this.currentRace.flag,
+            remainingSeconds: this.currentRace.remainingSeconds
+        };
+    }
+
+    getFlagState() {
+        return {
+            status: this.currentRace.status,
+            flag: this.currentRace.flag
+        };
+    }
+
     getNextSession() {
         if (this.sessions.length === 0) {
             return {

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -182,5 +182,3 @@ class Repository {
  }
 
 module.exports = Repository;
-
-    // addSession, updateSession, addDriver, updateDriver, deleteDriver, etc have to be implemented


### PR DESCRIPTION
What
Standardizes Socket.IO client/server event names and acknowledgement payloads in the backend.

Changes
- added centralized clientEvents constants
- added centralized serverEvents constants
- updated socket handlers to use shared event names
- standardized callback payload structure for race state and next race responses
- aligned socket event handling around predictable backend contracts

Notes
- this PR is focused on event naming and payload consistency
- it does not introduce new race control logic
- intended to reduce backend/frontend contract drift

Related
Closes #25