### PR TITLE
feat: implement front desk screen

### DIFF
--- a/frontend/app/package-lock.json
+++ b/frontend/app/package-lock.json
@@ -15,6 +15,7 @@
         "@angular/platform-browser": "^21.2.0",
         "@angular/router": "^21.2.0",
         "rxjs": "~7.8.0",
+        "socket.io-client": "^4.8.3",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -3840,6 +3841,12 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -4789,7 +4796,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4934,6 +4940,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/entities": {
@@ -6382,7 +6410,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/msgpackr": {
@@ -7635,6 +7662,34 @@
         "npm": ">= 3.0.0"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/socks": {
       "version": "2.8.7",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
@@ -8430,6 +8485,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -8446,6 +8522,14 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -18,6 +18,7 @@
     "@angular/platform-browser": "^21.2.0",
     "@angular/router": "^21.2.0",
     "rxjs": "~7.8.0",
+    "socket.io-client": "^4.8.3",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/frontend/app/src/app/screens/front-desk/front-desk.html
+++ b/frontend/app/src/app/screens/front-desk/front-desk.html
@@ -1,1 +1,179 @@
-<p>front-desk works!</p>
+<div class="auth-screen" *ngIf="!isAuthenticated">
+  <div class="auth-card">
+    <div class="auth-logo">
+      <h1>Front Desk</h1>
+      <p class="auth-subtitle">Reception Interface</p>
+    </div>
+
+    <div class="auth-form">
+      <label class="field-label" for="accessKey">Access Code</label>
+      <input
+        id="accessKey"
+        class="auth-input"
+        type="password"
+        placeholder="Enter code..."
+        [(ngModel)]="accessKey"
+        (keydown.enter)="login()"
+        [disabled]="isConnecting"
+        autocomplete="off"
+      />
+
+      <p class="auth-error" *ngIf="authError"> {{ authError }}</p>
+
+      <button
+        class="btn btn-primary btn-full"
+        (click)="login()"
+        [disabled]="isConnecting || !accessKey.trim()"
+      >
+        <span *ngIf="!isConnecting">Log in</span>
+        <span *ngIf="isConnecting" class="spinner">Connecting...</span>
+      </button>
+    </div>
+  </div>
+</div>
+
+
+<div class="dashboard" *ngIf="isAuthenticated">
+
+  <!-- Päis -->
+  <header class="dashboard-header">
+    <div class="header-left">
+      <div>
+        <h1 class="header-title">Front Desk</h1>
+        <p class="header-sub">Reception Interface</p>
+      </div>
+    </div>
+    <div class="header-right">
+      <span class="session-count">{{ sessions.length }} races</span>
+      <button class="btn btn-primary" (click)="createSession()">
+        + Add race
+      </button>
+    </div>
+  </header>
+
+  <!-- Empty state -->
+  <div class="empty-state" *ngIf="sessions.length === 0">
+    <p>No races have been added yet.</p>
+    <button class="btn btn-primary" (click)="createSession()">Add first race</button>
+  </div>
+
+  <div class="sessions-list" *ngIf="sessions.length > 0">
+
+    <div
+      class="session-card"
+      *ngFor="let session of sessions"
+      [class.locked]="isLocked(session)"
+    >
+      <div class="session-header">
+        <div class="session-title">
+          <span class="session-number">Race #{{ session.sessionId }}</span>
+          <span class="lock-badge" *ngIf="isLocked(session)">Locked</span>
+          <span class="driver-count">{{ session.driverNames.length }}/8 drivers</span>
+        </div>
+        <div class="session-actions">
+          <button
+            class="btn btn-danger btn-sm"
+            *ngIf="!isLocked(session)"
+            (click)="removeSession(session.sessionId)"
+            title="Delete race"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+
+      <div class="drivers-section">
+        <table class="drivers-table" *ngIf="session.driverNames.length > 0">
+          <thead>
+            <tr>
+              <th>Car #</th>
+              <th>Driver name</th>
+              <th *ngIf="!isLocked(session)">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let driver of getDrivers(session)">
+              <td class="car-number">
+                <span class="car-badge">{{ driver.carNumber }}</span>
+              </td>
+
+              <td *ngIf="isEditing(session.sessionId, driver.driverName)">
+                <input
+                  class="inline-input"
+                  type="text"
+                  [(ngModel)]="editingNewName"
+                  (keydown)="onKeyDown($event, 'confirmEdit')"
+                  autofocus
+                />
+              </td>
+
+              <td *ngIf="!isEditing(session.sessionId, driver.driverName)">
+                {{ driver.driverName }}
+              </td>
+
+              <td *ngIf="!isLocked(session)" class="driver-actions">
+                <ng-container *ngIf="isEditing(session.sessionId, driver.driverName)">
+                  <button class="btn btn-success btn-xs" (click)="confirmEdit()" title="Confirm">✓</button>
+                  <button class="btn btn-ghost btn-xs" (click)="cancelEdit()" title="Cancel">✕</button>
+                </ng-container>
+
+                <ng-container *ngIf="!isEditing(session.sessionId, driver.driverName)">
+                  <button
+                    class="btn btn-ghost btn-xs"
+                    (click)="startEdit(session.sessionId, driver.driverName)"
+                    title="Edit name"
+                  >✏</button>
+                  <button
+                    class="btn btn-danger btn-xs"
+                    (click)="removeDriver(session.sessionId, driver.driverName)"
+                    title="Remove driver"
+                  >Delete</button>
+                </ng-container>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p class="no-drivers" *ngIf="session.driverNames.length === 0 && !isLocked(session)">
+          No drivers added.
+        </p>
+
+        <div class="add-driver-form" *ngIf="canAddDriver(session)">
+          <input
+            class="driver-input"
+            type="text"
+            placeholder="Driver name..."
+            [(ngModel)]="newDriverName"
+            (keydown)="onKeyDown($event, 'addDriver', session.sessionId)"
+            *ngIf="expandedSessionId === session.sessionId"
+          />
+          <div class="add-driver-buttons">
+            <button
+              class="btn btn-secondary btn-sm"
+              *ngIf="expandedSessionId !== session.sessionId"
+              (click)="toggleExpand(session.sessionId)"
+            >
+              + Add driver
+            </button>
+            <ng-container *ngIf="expandedSessionId === session.sessionId">
+              <button
+                class="btn btn-success btn-sm"
+                (click)="addDriver(session.sessionId)"
+                [disabled]="!newDriverName.trim()"
+              >
+                ✓ Add
+              </button>
+              <button class="btn btn-ghost btn-sm" (click)="toggleExpand(session.sessionId)">
+                Cancel
+              </button>
+            </ng-container>
+          </div>
+        </div>
+
+        <p class="max-notice" *ngIf="session.driverNames.length >= 8 && !isLocked(session)">
+          Maximum number of drivers (8) reached.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/app/src/app/screens/front-desk/front-desk.html
+++ b/frontend/app/src/app/screens/front-desk/front-desk.html
@@ -143,7 +143,7 @@
             class="driver-input"
             type="text"
             placeholder="Driver name..."
-            [(ngModel)]="newDriverName"
+            [(ngModel)]="newDriverNames[session.sessionId]"
             (keydown)="onKeyDown($event, 'addDriver', session.sessionId)"
             *ngIf="expandedSessionId === session.sessionId"
           />
@@ -159,7 +159,7 @@
               <button
                 class="btn btn-success btn-sm"
                 (click)="addDriver(session.sessionId)"
-                [disabled]="!newDriverName.trim()"
+                [disabled]="!getNewDriverName(session.sessionId).trim()"
               >
                 ✓ Add
               </button>

--- a/frontend/app/src/app/screens/front-desk/front-desk.ts
+++ b/frontend/app/src/app/screens/front-desk/front-desk.ts
@@ -1,9 +1,248 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, OnDestroy, ChangeDetectorRef, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { io, Socket } from 'socket.io-client';
+
+interface Driver {
+  driverName: string;
+  carNumber: number;
+}
+
+interface Session {
+  sessionId: number;
+  driverNames: string[];
+  carNumbers: number[];
+  locked?: boolean; 
+}
 
 @Component({
   selector: 'app-front-desk',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule, FormsModule],
   templateUrl: './front-desk.html',
-  styleUrl: './front-desk.scss',
+  styleUrls: ['./front-desk.scss']
 })
-export class FrontDesk {}
+export class FrontDeskComponent implements OnInit, OnDestroy {
+
+  private socket!: Socket;
+  private readonly backendSocketUrl = `${window.location.protocol}//${window.location.hostname}:3000`;
+  private pendingLogin = false;
+  private loginTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private cdr = inject(ChangeDetectorRef);
+
+  sessions: Session[] = [];
+  accessKey: string = '';
+  isAuthenticated: boolean = false;
+  authError: string = '';
+  isConnecting: boolean = false;
+  expandedSessionId: number | null = null;
+  newDriverName: string = '';
+  editingDriver: { sessionId: number; driverName: string } | null = null;
+  editingNewName: string = '';
+
+  ngOnInit(): void {
+    this.initSocket();
+  }
+
+  ngOnDestroy(): void {
+    this.clearLoginTimeout();
+    if (this.socket) {
+      this.socket.disconnect();
+    }
+  }
+
+
+  private initSocket(): void {
+    this.socket = io(this.backendSocketUrl, {
+      autoConnect: false,
+      reconnection: true,
+      reconnectionAttempts: 5,
+      reconnectionDelay: 1000,
+      timeout: 5000
+    });
+
+    this.socket.on('connect', () => {
+      if (this.pendingLogin || this.isAuthenticated) {
+        this.pendingLogin = false;
+        this.joinRoom();
+      }
+    });
+
+    this.socket.on('connect_error', () => {
+      this.clearLoginTimeout();
+      this.isConnecting = false;
+      this.pendingLogin = false;
+      this.isAuthenticated = false;
+      this.authError = 'Cannot connect to server. Please check backend and try again.';
+      this.cdr.detectChanges();
+    });
+
+    this.socket.on('sessionsUpdated', (data: { sessions: Session[] }) => {
+      this.sessions = data.sessions;
+      this.cdr.detectChanges();
+    });
+
+    this.socket.on('sessionStarted', (data: { sessionId: number }) => {
+      const session = this.sessions.find(s => s.sessionId === data.sessionId);
+      if (session) {
+        session.locked = true;
+        this.cdr.detectChanges();
+      }
+    });
+  }
+
+  login(): void {
+    if (!this.accessKey.trim() || this.isConnecting) return;
+
+    this.isConnecting = true;
+    this.authError = '';
+    this.startLoginTimeout();
+
+    if (this.socket.connected) {
+      this.joinRoom();
+      return;
+    }
+
+    this.pendingLogin = true;
+    this.socket.connect();
+  }
+
+  private joinRoom(): void {
+    this.socket.timeout(5000).emit(
+      'selectRoom',
+      { room: 'front-desk', key: this.accessKey },
+      (err: Error | null, response: { status: string }) => {
+        this.clearLoginTimeout();
+        if (err) {
+          this.isConnecting = false;
+          this.isAuthenticated = false;
+          this.authError = 'Server did not respond in time. Please try again.';
+          this.cdr.detectChanges();
+          return;
+        }
+
+        this.isConnecting = false;
+        if (response.status === 'Success') {
+          this.isAuthenticated = true;
+          this.authError = '';
+        } else {
+          this.authError = 'Invalid code. Please try again.';
+          this.isAuthenticated = false;
+        }
+        this.cdr.detectChanges();
+      }
+    );
+  }
+
+  private startLoginTimeout(): void {
+    this.clearLoginTimeout();
+    this.loginTimeoutId = setTimeout(() => {
+      if (!this.isConnecting) {
+        return;
+      }
+      this.pendingLogin = false;
+      this.isAuthenticated = false;
+      this.isConnecting = false;
+      this.authError = 'Connection timed out. Please verify backend is running on port 3000.';
+      this.socket.disconnect();
+      this.cdr.detectChanges();
+    }, 8000);
+  }
+
+  private clearLoginTimeout(): void {
+    if (this.loginTimeoutId !== null) {
+      clearTimeout(this.loginTimeoutId);
+      this.loginTimeoutId = null;
+    }
+  }
+
+  createSession(): void {
+    this.socket.emit('sessionCreated');
+  }
+
+  removeSession(sessionId: number): void {
+    this.socket.emit('sessionRemoved', { sessionId });
+  }
+
+  toggleExpand(sessionId: number): void {
+    this.expandedSessionId = this.expandedSessionId === sessionId ? null : sessionId;
+    this.newDriverName = '';
+  }
+
+
+
+  addDriver(sessionId: number): void {
+    const name = this.newDriverName.trim();
+    if (!name) return;
+
+    this.socket.emit('driverAdded', { sessionId, driverName: name });
+    this.newDriverName = '';
+  }
+
+  startEdit(sessionId: number, driverName: string): void {
+    this.editingDriver = { sessionId, driverName };
+    this.editingNewName = driverName;
+  }
+
+  confirmEdit(): void {
+    if (!this.editingDriver) return;
+    const newName = this.editingNewName.trim();
+    if (!newName || newName === this.editingDriver.driverName) {
+      this.cancelEdit();
+      return;
+    }
+
+    this.socket.emit('driverEdited', {
+      sessionId: this.editingDriver.sessionId,
+      driverName: this.editingDriver.driverName,
+      newName
+    });
+    this.editingDriver = null;
+  }
+
+  cancelEdit(): void {
+    this.editingDriver = null;
+    this.editingNewName = '';
+  }
+
+  removeDriver(sessionId: number, driverName: string): void {
+    this.socket.emit('driverRemoved', { sessionId, driverName });
+  }
+
+  isLocked(session: Session): boolean {
+    return session.locked === true;
+  }
+
+  isEditing(sessionId: number, driverName: string): boolean {
+    return (
+      this.editingDriver?.sessionId === sessionId &&
+      this.editingDriver?.driverName === driverName
+    );
+  }
+
+  getDrivers(session: Session): Driver[] {
+    return session.driverNames.map((name, i) => ({
+      driverName: name,
+      carNumber: session.carNumbers[i]
+    }));
+  }
+
+  canAddDriver(session: Session): boolean {
+    return session.driverNames.length < 8 && !this.isLocked(session);
+  }
+
+  onKeyDown(event: KeyboardEvent, action: 'addDriver' | 'confirmEdit', sessionId?: number): void {
+    if (event.key === 'Enter') {
+      if (action === 'addDriver' && sessionId !== undefined) {
+        this.addDriver(sessionId);
+      } else if (action === 'confirmEdit') {
+        this.confirmEdit();
+      }
+    }
+    if (event.key === 'Escape' && action === 'confirmEdit') {
+      this.cancelEdit();
+    }
+  }
+}
+
+export { FrontDeskComponent as FrontDesk };

--- a/frontend/app/src/app/screens/front-desk/front-desk.ts
+++ b/frontend/app/src/app/screens/front-desk/front-desk.ts
@@ -25,9 +25,9 @@ interface Session {
 export class FrontDeskComponent implements OnInit, OnDestroy {
 
   private socket!: Socket;
-  private readonly backendSocketUrl = `${window.location.protocol}//${window.location.hostname}:3000`;
   private pendingLogin = false;
   private loginTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private readonly lockedSessionIds = new Set<number>();
   private cdr = inject(ChangeDetectorRef);
 
   sessions: Session[] = [];
@@ -53,7 +53,7 @@ export class FrontDeskComponent implements OnInit, OnDestroy {
 
 
   private initSocket(): void {
-    this.socket = io(this.backendSocketUrl, {
+    this.socket = io({
       autoConnect: false,
       reconnection: true,
       reconnectionAttempts: 5,
@@ -78,11 +78,15 @@ export class FrontDeskComponent implements OnInit, OnDestroy {
     });
 
     this.socket.on('sessionsUpdated', (data: { sessions: Session[] }) => {
-      this.sessions = data.sessions;
+      this.sessions = data.sessions.map(session => ({
+        ...session,
+        locked: session.locked === true || this.lockedSessionIds.has(session.sessionId)
+      }));
       this.cdr.detectChanges();
     });
 
     this.socket.on('sessionStarted', (data: { sessionId: number }) => {
+      this.lockedSessionIds.add(data.sessionId);
       const session = this.sessions.find(s => s.sessionId === data.sessionId);
       if (session) {
         session.locked = true;
@@ -143,7 +147,7 @@ export class FrontDeskComponent implements OnInit, OnDestroy {
       this.pendingLogin = false;
       this.isAuthenticated = false;
       this.isConnecting = false;
-      this.authError = 'Connection timed out. Please verify backend is running on port 3000.';
+      this.authError = 'Connection timed out. Please try again.';
       this.socket.disconnect();
       this.cdr.detectChanges();
     }, 8000);

--- a/frontend/app/src/app/screens/front-desk/front-desk.ts
+++ b/frontend/app/src/app/screens/front-desk/front-desk.ts
@@ -36,7 +36,7 @@ export class FrontDeskComponent implements OnInit, OnDestroy {
   authError: string = '';
   isConnecting: boolean = false;
   expandedSessionId: number | null = null;
-  newDriverName: string = '';
+  newDriverNames: Record<number, string> = {};
   editingDriver: { sessionId: number; driverName: string } | null = null;
   editingNewName: string = '';
 
@@ -70,14 +70,22 @@ export class FrontDeskComponent implements OnInit, OnDestroy {
 
     this.socket.on('connect_error', () => {
       this.clearLoginTimeout();
-      this.isConnecting = false;
-      this.pendingLogin = false;
-      this.isAuthenticated = false;
-      this.authError = 'Cannot connect to server. Please check backend and try again.';
+      if (this.isAuthenticated) {
+        this.authError = '';
+      } else {
+        this.isConnecting = false;
+        this.pendingLogin = false;
+        this.isAuthenticated = false;
+        this.authError = 'Cannot connect to server. Please check backend and try again.';
+      }
       this.cdr.detectChanges();
     });
 
     this.socket.on('sessionsUpdated', (data: { sessions: Session[] }) => {
+      const activeSessionIds = new Set(data.sessions.map((session) => session.sessionId));
+      this.pruneLockedSessionIds(activeSessionIds);
+      this.pruneNewDriverNames(activeSessionIds);
+      this.clearStaleUiState(activeSessionIds);
       this.sessions = data.sessions.map(session => ({
         ...session,
         locked: session.locked === true || this.lockedSessionIds.has(session.sessionId)
@@ -119,8 +127,10 @@ export class FrontDeskComponent implements OnInit, OnDestroy {
         this.clearLoginTimeout();
         if (err) {
           this.isConnecting = false;
-          this.isAuthenticated = false;
-          this.authError = 'Server did not respond in time. Please try again.';
+          if (!this.isAuthenticated) {
+            this.isAuthenticated = false;
+            this.authError = 'Server did not respond in time. Please try again.';
+          }
           this.cdr.detectChanges();
           return;
         }
@@ -169,18 +179,23 @@ export class FrontDeskComponent implements OnInit, OnDestroy {
   }
 
   toggleExpand(sessionId: number): void {
-    this.expandedSessionId = this.expandedSessionId === sessionId ? null : sessionId;
-    this.newDriverName = '';
+    if (this.expandedSessionId === sessionId) {
+      delete this.newDriverNames[sessionId];
+      this.expandedSessionId = null;
+      return;
+    }
+
+    this.expandedSessionId = sessionId;
   }
 
 
 
   addDriver(sessionId: number): void {
-    const name = this.newDriverName.trim();
+    const name = this.getNewDriverName(sessionId).trim();
     if (!name) return;
 
     this.socket.emit('driverAdded', { sessionId, driverName: name });
-    this.newDriverName = '';
+    delete this.newDriverNames[sessionId];
   }
 
   startEdit(sessionId: number, driverName: string): void {
@@ -231,6 +246,10 @@ export class FrontDeskComponent implements OnInit, OnDestroy {
     }));
   }
 
+  getNewDriverName(sessionId: number): string {
+    return this.newDriverNames[sessionId] ?? '';
+  }
+
   canAddDriver(session: Session): boolean {
     return session.driverNames.length < 8 && !this.isLocked(session);
   }
@@ -244,6 +263,33 @@ export class FrontDeskComponent implements OnInit, OnDestroy {
       }
     }
     if (event.key === 'Escape' && action === 'confirmEdit') {
+      this.cancelEdit();
+    }
+  }
+
+  private pruneLockedSessionIds(activeSessionIds: Set<number>): void {
+    for (const sessionId of this.lockedSessionIds) {
+      if (!activeSessionIds.has(sessionId)) {
+        this.lockedSessionIds.delete(sessionId);
+      }
+    }
+  }
+
+  private pruneNewDriverNames(activeSessionIds: Set<number>): void {
+    for (const sessionId of Object.keys(this.newDriverNames)) {
+      const numericSessionId = Number(sessionId);
+      if (!activeSessionIds.has(numericSessionId)) {
+        delete this.newDriverNames[numericSessionId];
+      }
+    }
+  }
+
+  private clearStaleUiState(activeSessionIds: Set<number>): void {
+    if (this.expandedSessionId !== null && !activeSessionIds.has(this.expandedSessionId)) {
+      this.expandedSessionId = null;
+    }
+
+    if (this.editingDriver && !activeSessionIds.has(this.editingDriver.sessionId)) {
       this.cancelEdit();
     }
   }


### PR DESCRIPTION
## Summary

Implements the front desk (receptionist) screen, allowing reception
staff to manage race sessions and drivers before a race starts.

## Changes

- Socket.IO connection using same origin as frontend (per API spec)
- Authentication flow with access key via `selectRoom` event
- Session management: create and remove sessions
- Driver management: add, edit, and remove drivers per session (max 8)
- Session locking on `sessionStarted` event — editing is disabled for
  started sessions; lock state is preserved across `sessionsUpdated`
  events using an in-memory Set
- Reconnection handling: `selectRoom` is re-sent automatically on
  reconnect if already authenticated

## API events handled

| Event | Direction |
|---|---|
| `selectRoom` | client → server |
| `sessionsUpdated` | server → client |
| `sessionStarted` | server → client |
| `sessionCreated` | client → server |
| `sessionRemoved` | client → server |
| `driverAdded` | client → server |
| `driverEdited` | client → server |
| `driverRemoved` | client → server |

## Testing

- Manual testing against local backend
- Verified session lock persists after subsequent `sessionsUpdated` events
- Verified reconnect re-authenticates without user interaction