### PR TITLE
feat: implement leaderboard screen

### DIFF
--- a/frontend/app/src/app/screens/leader-board/leader-board.html
+++ b/frontend/app/src/app/screens/leader-board/leader-board.html
@@ -1,6 +1,8 @@
 <div>
   <button (click)="enterFullscreen()">Full Screen</button>
 
+  <p *ngIf="connectionError">{{ connectionError }}</p>
+
   <!-- Timer and flag status -->
   <div>
     <span>Time Remaining: {{ formatTime(remainingSeconds) }}</span>

--- a/frontend/app/src/app/screens/leader-board/leader-board.html
+++ b/frontend/app/src/app/screens/leader-board/leader-board.html
@@ -1,1 +1,34 @@
-<p>leader-board works!</p>
+<div>
+  <button (click)="enterFullscreen()">Full Screen</button>
+
+  <!-- Timer and flag status -->
+  <div>
+    <span>Time Remaining: {{ formatTime(remainingSeconds) }}</span>
+    <span> | Flag: {{ currentFlag ?? 'none' }}</span>
+    <span> | Status: {{ sessionStatus }}</span>
+  </div>
+
+  <!-- Leaderboard table -->
+  <table *ngIf="entries.length > 0">
+    <thead>
+      <tr>
+        <th>Position</th>
+        <th>Car</th>
+        <th>Driver</th>
+        <th>Laps</th>
+        <th>Best Lap</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let entry of sortedEntries; let i = index">
+        <td>{{ i + 1 }}</td>
+        <td>{{ entry.carNumber }}</td>
+        <td>{{ entry.driverName }}</td>
+        <td>{{ entry.completedLaps }}</td>
+        <td>{{ formatLapTime(entry.bestLapTime) }}</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p *ngIf="entries.length === 0">No active race session.</p>
+</div>

--- a/frontend/app/src/app/screens/leader-board/leader-board.ts
+++ b/frontend/app/src/app/screens/leader-board/leader-board.ts
@@ -1,9 +1,103 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { io, Socket } from 'socket.io-client';
+
+type SessionStatus = 'notStarted' | 'active' | 'finished';
+type RaceFlag = 'green' | 'yellow' | 'red' | 'finish';
+
+interface LeaderboardEntry {
+  carNumber: number;
+  driverName: string;
+  completedLaps: number;
+  bestLapTime: number; // milliseconds, 0 = no lap yet
+}
 
 @Component({
   selector: 'app-leader-board',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './leader-board.html',
   styleUrl: './leader-board.scss',
 })
-export class LeaderBoard {}
+export class LeaderBoard implements OnInit, OnDestroy {
+  private socket!: Socket;
+
+  sessionStatus: SessionStatus = 'notStarted';
+  currentFlag: RaceFlag | null = null;
+  remainingSeconds = 0;
+  entries: LeaderboardEntry[] = [];
+
+  get sortedEntries(): LeaderboardEntry[] {
+    return [...this.entries].sort((a, b) => {
+      if (a.bestLapTime === 0 && b.bestLapTime === 0) return 0;
+      if (a.bestLapTime === 0) return 1;
+      if (b.bestLapTime === 0) return -1;
+      return a.bestLapTime - b.bestLapTime;
+    });
+  }
+
+  ngOnInit(): void {
+    this.socket = io();
+
+    this.socket.on('connect', () => {
+      this.socket.emit('selectRoom', { room: 'leader-board' }, (response: { status: string }) => {
+        console.log('Leader board room:', response?.status);
+      });
+    });
+
+    this.socket.on('sessionUpdate', (args: { sessionId: number; driverNames: string[]; carNumbers: number[] }) => {
+      this.entries = args.carNumbers.map((carNumber, i) => ({
+        carNumber,
+        driverName: args.driverNames[i],
+        completedLaps: 0,
+        bestLapTime: 0,
+      }));
+    });
+
+    this.socket.on('sessionStatus', (args: { status: SessionStatus }) => {
+      this.sessionStatus = args.status;
+    });
+
+    this.socket.on('flagChanged', (args: { flag: RaceFlag }) => {
+      this.currentFlag = args.flag;
+    });
+
+    this.socket.on('lapTimes', (args: { carNumbers: number[]; completedLaps: number[]; bestLapTime: number[] }) => {
+      args.carNumbers.forEach((carNumber, i) => {
+        const entry = this.entries.find(e => e.carNumber === carNumber);
+        if (entry) {
+          entry.completedLaps = args.completedLaps[i];
+          entry.bestLapTime = args.bestLapTime[i];
+        }
+      });
+    });
+
+    this.socket.on('timerTick', (args: { remainingSeconds: number }) => {
+      this.remainingSeconds = args.remainingSeconds;
+    });
+  }
+
+  ngOnDestroy(): void {
+    if (this.socket) {
+      this.socket.disconnect();
+    }
+  }
+
+  formatLapTime(ms: number): string {
+    if (ms === 0) return '—';
+    const minutes = Math.floor(ms / 60000);
+    const seconds = Math.floor((ms % 60000) / 1000);
+    const millis = ms % 1000;
+    return `${minutes}:${String(seconds).padStart(2, '0')}.${String(millis).padStart(3, '0')}`;
+  }
+
+  formatTime(totalSeconds: number): string {
+    const m = Math.floor(totalSeconds / 60);
+    const s = totalSeconds % 60;
+    return `${m}:${String(s).padStart(2, '0')}`;
+  }
+
+  enterFullscreen(): void {
+    document.documentElement.requestFullscreen();
+  }
+}

--- a/frontend/app/src/app/screens/leader-board/leader-board.ts
+++ b/frontend/app/src/app/screens/leader-board/leader-board.ts
@@ -26,6 +26,7 @@ export class LeaderBoard implements OnInit, OnDestroy {
   currentFlag: RaceFlag | null = null;
   remainingSeconds = 0;
   entries: LeaderboardEntry[] = [];
+  connectionError: string | null = null;
 
   get sortedEntries(): LeaderboardEntry[] {
     return [...this.entries].sort((a, b) => {
@@ -41,7 +42,11 @@ export class LeaderBoard implements OnInit, OnDestroy {
 
     this.socket.on('connect', () => {
       this.socket.emit('selectRoom', { room: 'leader-board' }, (response: { status: string }) => {
-        console.log('Leader board room:', response?.status);
+        if (response?.status !== 'Success') {
+          this.connectionError = 'Connection failed: ' + (response?.status ?? 'Unknown error');
+        } else {
+          this.connectionError = null;
+        }
       });
     });
 
@@ -98,6 +103,8 @@ export class LeaderBoard implements OnInit, OnDestroy {
   }
 
   enterFullscreen(): void {
-    document.documentElement.requestFullscreen();
+    document.documentElement.requestFullscreen().catch((err) => {
+      console.warn('Fullscreen failed:', err);
+    });
   }
 }


### PR DESCRIPTION
## Summary
This PR implements the full leader-board component, enabling spectators to follow live race data in real time.

## Changes

- Implemented `LeaderBoard` Angular component with Socket.IO connection
- Joins `leader-board` room on connect and on every reconnect
- Handles all events per API specification:
  - `sessionUpdate` – loads drivers and car assignments for the session
  - `sessionStatus` – tracks race state (notStarted / active / finished)
  - `flagChanged` – displays current race flag status
  - `lapTimes` – updates completed laps and best lap time per car
  - `timerTick` – updates the remaining race time every second
- Entries are sorted by fastest lap time; cars with no lap yet appear last
- Lap times are formatted as `m:ss.ms`
- Full screen button included for large display use cases
