### PR TITLE
feat(be): implement race start countdown event

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -38,16 +38,6 @@ if (!("NODE_ENV" in env)) {
 
 const repository = new Repository(raceDuration);
 
-function broadcastRaceState() {
-    io.to("race-control").emit("raceStateUpdate", repository.currentRace);
-    io.to("leader-board").emit("raceStateUpdate", repository.currentRace);
-    io.to("race-countdown").emit("raceStateUpdate", repository.currentRace);
-    io.to("race-flags").emit("raceStateUpdate", repository.currentRace);
-    io.to("next-race").emit("raceStateUpdate", repository.currentRace);
-    io.to("lap-line-tracker").emit("raceStateUpdate", repository.currentRace);
-    io.to("front-desk").emit("raceStateUpdate", repository.currentRace);    
-}
-
 io.on('connection', (socket) => {
     socket.on("selectRoom", (args, callback) => {
         if (publicRooms.includes(args.room)) {
@@ -83,7 +73,9 @@ io.on('connection', (socket) => {
             return;
         }
 
-        broadcastRaceState();
+        io.to("race-countdown").emit("startCountDown", {
+            remainingSeconds: repository.currentRace.remainingSeconds
+        });
         callback({ status: "Success" });
     });
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -76,7 +76,7 @@ io.on('connection', (socket) => {
             return;
         }
 
-        const result = repository.raceStartCountdown();
+        const result = repository.beginStartCountdown();
 
         if (result !== "Success") {
             callback({ status: result });

--- a/backend/index.js
+++ b/backend/index.js
@@ -70,19 +70,16 @@ io.on('connection', (socket) => {
         }
     });
 
-    socket.on("startRace", (callback) => {
+    socket.on("raceStartCountdown", (callback) => {
         if (!socket.rooms.has("race-control")) {
-            callback({
-                status: "Error",
-                message: "Unauthorized"
-            });
+            callback({ status: "Invalid Session Status" });
             return;
         }
 
-        const result = repository.startRace();
+        const result = repository.raceStartCountdown();
 
-        if (result.status !== "Success") {
-            callback(result);
+        if (result !== "Success") {
+            callback({ status: result });
             return;
         }
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -44,6 +44,8 @@ function broadcastRaceState() {
     io.to("race-countdown").emit("raceStateUpdate", repository.currentRace);
     io.to("race-flags").emit("raceStateUpdate", repository.currentRace);
     io.to("next-race").emit("raceStateUpdate", repository.currentRace);
+    io.to("lap-line-tracker").emit("raceStateUpdate", repository.currentRace);
+    io.to("front-desk").emit("raceStateUpdate", repository.currentRace);    
 }
 
 io.on('connection', (socket) => {
@@ -51,6 +53,7 @@ io.on('connection', (socket) => {
         if (publicRooms.includes(args.room)) {
             socket.join(args.room);
             callback({status: "Success"});
+            onConnection(socket, repository, args.room);
         } else if (privateRooms.includes(args.room)) {
             if (args.key === privateRoomKeys[args.room]) {
                 socket.join(args.room);

--- a/backend/index.js
+++ b/backend/index.js
@@ -38,6 +38,14 @@ if (!("NODE_ENV" in env)) {
 
 const repository = new Repository(raceDuration);
 
+function broadcastRaceState() {
+    io.to("race-control").emit("raceStateUpdate", repository.currentRace);
+    io.to("leader-board").emit("raceStateUpdate", repository.currentRace);
+    io.to("race-countdown").emit("raceStateUpdate", repository.currentRace);
+    io.to("race-flags").emit("raceStateUpdate", repository.currentRace);
+    io.to("next-race").emit("raceStateUpdate", repository.currentRace);
+}
+
 io.on('connection', (socket) => {
     socket.on("selectRoom", (args, callback) => {
         if (publicRooms.includes(args.room)) {
@@ -58,5 +66,28 @@ io.on('connection', (socket) => {
             callback({status: "Invalid Room"});
         }
     });
+
+    socket.on("startRace", (callback) => {
+        if (!socket.rooms.has("race-control")) {
+            callback({
+                status: "Error",
+                message: "Unauthorized"
+            });
+            return;
+        }
+
+        const result = repository.startRace();
+
+        if (result.status !== "Success") {
+            callback(result);
+            return;
+        }
+
+        broadcastRaceState();
+        callback({ status: "Success" });
+    });
+
     // Event listeners as modules can be added here
 });
+
+console.log("Socket.IO backend running on port 3000");

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -55,7 +55,12 @@ class Repository {
                 message: "No session loaded"
             };
         }
-        this.currentRace.status = "running";
+        if (this.currentRace.status === "active") {
+            return {
+                status: "Error",
+                message: "Race already active"
+            };
+        }
         this.currentRace.flag = "green";
         this.currentRace.remainingSeconds = this.defaultRaceDuration;
 

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -52,7 +52,7 @@ class Repository {
         if (this.currentRace.sessionId === null) {
             return "Invalid Session Status";
         }
-        if (this.currentRace.status === "active") {
+        if (this.currentRace.status !== "notStarted") {
             return "Invalid Session Status";
         }
         this.currentRace.remainingSeconds = this.defaultRaceDuration;

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -48,26 +48,16 @@ class Repository {
         return "Session not found";
     }
 
-    startRace() {
+    beginStartCountdown() {
         if (this.currentRace.sessionId === null) {
-            return {
-                status: "Error",
-                message: "No session loaded"
-            };
+            return "Invalid Session Status";
         }
         if (this.currentRace.status === "active") {
-            return {
-                status: "Error",
-                message: "Race already active"
-            };
+            return "Invalid Session Status";
         }
-        this.currentRace.flag = "green";
         this.currentRace.remainingSeconds = this.defaultRaceDuration;
 
-        return {
-            status: "Success",
-            race: this.currentRace
-        };
+        return "Success";
     }
 
      // addSession, updateSession, addDriver, updateDriver, deleteDriver, etc have to be implemented

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -47,5 +47,27 @@ class Repository {
         }
         return "Session not found";
     }
+
+    startRace() {
+        if (this.currentRace.sessionId === null) {
+            return {
+                status: "Error",
+                message: "No session loaded"
+            };
+        }
+        this.currentRace.status = "running";
+        this.currentRace.flag = "green";
+        this.currentRace.remainingSeconds = this.defaultRaceDuration;
+
+        return {
+            status: "Success",
+            race: this.currentRace
+        };
+    }
+
+     // addSession, updateSession, addDriver, updateDriver, deleteDriver, etc have to be implemented
+ }
+
+module.exports = Repository;
+
     // addSession, updateSession, addDriver, updateDriver, deleteDriver, etc have to be implemented
-}


### PR DESCRIPTION
What
Implements backend support for starting the race countdown from race-control.

Changes
- added repository method for beginning the race start countdown
- added Socket.IO event raceStartCountdown
- validates that a session is loaded before starting the countdown
- prevents countdown start when the session is already active
- resets remainingSeconds to the configured default race duration
- broadcasts updated race state after a successful countdown start

Notes
- only race-control can trigger the countdown
- this PR focuses on the documented race start countdown event contract
- no broader socket event refactor is included here

Related
Closes #18