### PR TITLE
feat: Implement lap-line-tracker with Socket.IO

### DIFF
--- a/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.html
+++ b/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.html
@@ -1,1 +1,51 @@
-<p>lap-line-tracker works!</p>
+<section style="max-width: 980px; margin: 0 auto; padding: 1rem;">
+	<h1>Lap-line Tracker</h1>
+
+	<div *ngIf="!isAuthenticated" style="display: grid; gap: 0.75rem; max-width: 420px;">
+		<label for="accessKey">Access key</label>
+		<input
+			id="accessKey"
+			type="password"
+			[(ngModel)]="accessKey"
+			[disabled]="isConnecting"
+			(keydown.enter)="connect()"
+			placeholder="Enter lap-line access key"
+			style="padding: 0.75rem; font-size: 1rem;"
+		/>
+		<button
+			type="button"
+			(click)="connect()"
+			[disabled]="isConnecting || !accessKey.trim()"
+			style="padding: 0.75rem 1rem; font-size: 1rem;"
+		>
+			{{ isConnecting ? 'Connecting...' : 'Connect' }}
+		</button>
+
+		<p *ngIf="authError" style="color: #b00020; margin: 0;">{{ authError }}</p>
+	</div>
+
+	<div *ngIf="isAuthenticated" style="display: grid; gap: 1rem;">
+		<p style="margin: 0; font-weight: 600;">Session status: {{ sessionStatus }}</p>
+		<p style="margin: 0;">{{ statusMessage }}</p>
+
+		<div
+			style="display: grid; gap: 0.75rem; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));"
+			aria-label="Lap buttons"
+		>
+			<button
+				*ngFor="let carNumber of carNumbers; trackBy: trackByCarNumber"
+				type="button"
+				(click)="sendLap(carNumber)"
+				[disabled]="!canRecordLaps"
+				[attr.aria-label]="'Record lap for car ' + carNumber"
+				style="min-height: 96px; font-size: 1.5rem; font-weight: 700;"
+			>
+				Car {{ carNumber }}
+			</button>
+		</div>
+
+		<p *ngIf="!canRecordLaps" style="margin: 0;">
+			Lap buttons are disabled until race status is active or finished.
+		</p>
+	</div>
+</section>

--- a/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.ts
+++ b/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.ts
@@ -1,9 +1,140 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { io, Socket } from 'socket.io-client';
+
+type SessionStatus = 'notStarted' | 'active' | 'finished';
 
 @Component({
   selector: 'app-lap-line-tracker',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule, FormsModule],
   templateUrl: './lap-line-tracker.html',
   styleUrl: './lap-line-tracker.scss',
 })
-export class LapLineTracker {}
+export class LapLineTracker implements OnInit, OnDestroy {
+  private socket!: Socket;
+
+  readonly carNumbers = [1, 2, 3, 4, 5, 6, 7, 8];
+
+  accessKey = '';
+  isAuthenticated = false;
+  isConnecting = false;
+  isConnected = false;
+  authError = '';
+  statusMessage = 'Enter access key to connect.';
+  sessionStatus: SessionStatus = 'notStarted';
+
+  private hasRaceProgressed = false;
+
+  ngOnInit(): void {
+    this.socket = io({ autoConnect: false, reconnection: true });
+
+    this.socket.on('connect', () => {
+      this.isConnected = true;
+      this.joinLapLineRoom();
+    });
+
+    this.socket.on('disconnect', () => {
+      this.isConnected = false;
+      if (this.isAuthenticated) {
+        this.statusMessage = 'Connection lost. Reconnecting...';
+      }
+    });
+
+    this.socket.on('connect_error', () => {
+      this.isConnecting = false;
+      this.isConnected = false;
+      this.statusMessage = 'Unable to connect to server.';
+    });
+
+    this.socket.on('sessionStatus', (args: { status: SessionStatus }) => {
+      const previousStatus = this.sessionStatus;
+      this.sessionStatus = args.status;
+
+      if (args.status === 'active' || args.status === 'finished') {
+        this.hasRaceProgressed = true;
+      }
+
+      if (args.status === 'active') {
+        this.statusMessage = 'Race active. Tap car buttons as cars cross the line.';
+        return;
+      }
+
+      if (args.status === 'finished') {
+        this.statusMessage = 'Finish mode active. Final laps can still be recorded.';
+        return;
+      }
+
+      if (args.status === 'notStarted' && this.hasRaceProgressed && previousStatus !== 'notStarted') {
+        this.statusMessage = 'Race session ended. Lap input is disabled between sessions.';
+        return;
+      }
+
+      this.statusMessage = 'Waiting for race start.';
+    });
+  }
+
+  ngOnDestroy(): void {
+    if (this.socket) {
+      this.socket.disconnect();
+    }
+  }
+
+  connect(): void {
+    if (!this.accessKey.trim() || this.isConnecting) {
+      return;
+    }
+
+    this.isConnecting = true;
+    this.authError = '';
+    this.statusMessage = 'Connecting...';
+
+    if (this.socket.connected) {
+      this.joinLapLineRoom();
+      return;
+    }
+
+    this.socket.connect();
+  }
+
+  sendLap(carNumber: number): void {
+    if (!this.canRecordLaps) {
+      return;
+    }
+
+    this.socket.emit('lap', { carNumber });
+  }
+
+  get canRecordLaps(): boolean {
+    return this.isAuthenticated && this.isConnected && this.sessionStatus !== 'notStarted';
+  }
+
+  trackByCarNumber(_index: number, carNumber: number): number {
+    return carNumber;
+  }
+
+  private joinLapLineRoom(): void {
+    this.socket.emit(
+      'selectRoom',
+      { room: 'lap-line-tracker', key: this.accessKey },
+      (response: { status: string }) => {
+        this.isConnecting = false;
+
+        if (response?.status === 'Success') {
+          this.isAuthenticated = true;
+          this.authError = '';
+          this.statusMessage = 'Connected. Waiting for race start.';
+          return;
+        }
+
+        this.isAuthenticated = false;
+        this.authError = response?.status === 'Invalid Access Key'
+          ? 'Invalid access key. Please try again.'
+          : (response?.status ?? 'Room connection failed.');
+        this.statusMessage = 'Authentication required.';
+        this.socket.disconnect();
+      }
+    );
+  }
+}


### PR DESCRIPTION
This PR implements the Lap-line Tracker frontend screen for the Lap-line Observer role. The screen now supports authenticated real-time communication and lap input handling according to the Socket.IO API requirements.

### What was added

- Access key prompt before establishing functional screen access
- Socket.IO room selection flow for lap-line-tracker
- Real-time session status handling for:
  - notStarted
  - active
  - finished
- Lap event emission with selected car number
- Large, easy-to-tap buttons for cars 1 to 8
- UI state control so lap buttons are disabled between sessions and available when race status allows input
- Basic connection and authentication feedback messages for the user

### API compliance

- Uses selectRoom with room and key for authenticated entry
- Listens to sessionStatus updates from the server
- Sends lap events with carNumber payload
- Keeps behavior aligned with race-state expectations for lap input

### Scope

- Updated only the Lap-line Tracker TypeScript and HTML files
- No backend changes
- No changes to other frontend screens