### PR TITLE
Implement next race screen

### DIFF
--- a/frontend/app/src/app/screens/next-race/next-race.html
+++ b/frontend/app/src/app/screens/next-race/next-race.html
@@ -1,17 +1,32 @@
-<div class="next-race">
-  <button class="fullscreen-btn" (click)="enterFullscreen()">Full Screen</button>
+<p>next-race works!</p>
 
+<div class="next-race">
+  <button type="button" (click)="enterFullscreen()">Full Screen</button>
+
+  <h1>Next Race</h1>
   <p><strong>Connection:</strong> {{ connected ? 'Connected' : 'Disconnected' }}</p>
   <p><strong>Message:</strong> {{ message }}</p>
 
-  <ng-container *ngIf="(nextSession?.driverNames?.length ?? 0) > 0; else noSession">
-    <p><strong>Session ID:</strong> {{ nextSession?.sessionId }}</p>
-    
-        <ul>
-      <li *ngFor="let pair of getDriverCarPairs()">
-        Driver: {{ pair.driver }} | Car: {{ pair.car }}
-      </li>
-    </ul>
+  <ng-container *ngIf="nextSession; else noSession">
+    <p><strong>Session ID:</strong> {{ nextSession.sessionId }}</p>
+    <p *ngIf="nextSession.status"><strong>Status:</strong> {{ nextSession.status }}</p>
+
+    <ng-container *ngIf="getDriverCarPairs().length > 0; else noDriversYet">
+      <h2>Drivers and cars</h2>
+      <ul>
+        <li *ngFor="let item of getDriverCarPairs()">
+          {{ item.driver }} — Car {{ item.car }}
+        </li>
+      </ul>
+    </ng-container>
+
+    <ng-template #noDriversYet>
+      <p>No drivers have been assigned yet.</p>
+    </ng-template>
+
+    <p *ngIf="nextSession.status === 'ended'">
+      Please proceed to the paddock.
+    </p>
   </ng-container>
 
   <ng-template #noSession>

--- a/frontend/app/src/app/screens/next-race/next-race.html
+++ b/frontend/app/src/app/screens/next-race/next-race.html
@@ -1,17 +1,15 @@
 <div class="next-race">
-  <h1>Next Race</h1>
+  <button class="fullscreen-btn" (click)="enterFullscreen()">Full Screen</button>
 
   <p><strong>Connection:</strong> {{ connected ? 'Connected' : 'Disconnected' }}</p>
   <p><strong>Message:</strong> {{ message }}</p>
 
-  <ng-container *ngIf="nextSession; else noSession">
-    <p><strong>Session ID:</strong> {{ nextSession.sessionId }}</p>
-    <p><strong>Status:</strong> {{ nextSession.status }}</p>
-
-    <h2>Drivers and cars</h2>
-    <ul>
-      <li *ngFor="let item of getDriverCarPairs()">
-        {{ item.driver }} — Car {{ item.car }}
+  <ng-container *ngIf="(nextSession?.driverNames?.length ?? 0) > 0; else noSession">
+    <p><strong>Session ID:</strong> {{ nextSession?.sessionId }}</p>
+    
+        <ul>
+      <li *ngFor="let pair of getDriverCarPairs()">
+        Driver: {{ pair.driver }} | Car: {{ pair.car }}
       </li>
     </ul>
   </ng-container>

--- a/frontend/app/src/app/screens/next-race/next-race.html
+++ b/frontend/app/src/app/screens/next-race/next-race.html
@@ -1,1 +1,22 @@
-<p>next-race works!</p>
+<div class="next-race">
+  <h1>Next Race</h1>
+
+  <p><strong>Connection:</strong> {{ connected ? 'Connected' : 'Disconnected' }}</p>
+  <p><strong>Message:</strong> {{ message }}</p>
+
+  <ng-container *ngIf="nextSession; else noSession">
+    <p><strong>Session ID:</strong> {{ nextSession.sessionId }}</p>
+    <p><strong>Status:</strong> {{ nextSession.status }}</p>
+
+    <h2>Drivers and cars</h2>
+    <ul>
+      <li *ngFor="let item of getDriverCarPairs()">
+        {{ item.driver }} — Car {{ item.car }}
+      </li>
+    </ul>
+  </ng-container>
+
+  <ng-template #noSession>
+    <p>No upcoming session available.</p>
+  </ng-template>
+</div>

--- a/frontend/app/src/app/screens/next-race/next-race.scss
+++ b/frontend/app/src/app/screens/next-race/next-race.scss
@@ -1,0 +1,3 @@
+.next-race {
+  padding: 24px;
+}

--- a/frontend/app/src/app/screens/next-race/next-race.ts
+++ b/frontend/app/src/app/screens/next-race/next-race.ts
@@ -1,9 +1,66 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { io, Socket } from 'socket.io-client';
+
+type NextSessionPayload = {
+  sessionId: number;
+  drivers: string[];
+  cars: number[];
+  status: string;
+};
 
 @Component({
   selector: 'app-next-race',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './next-race.html',
-  styleUrl: './next-race.scss',
+  styleUrls: ['./next-race.scss'],
 })
-export class NextRace {}
+export class NextRace implements OnInit, OnDestroy {
+  private socket!: Socket;
+
+  connected = false;
+  message = '';
+  nextSession: NextSessionPayload | null = null;
+
+  ngOnInit(): void {
+    this.socket = io();
+
+    this.socket.on('connect', () => {
+      this.connected = true;
+      this.message = 'Connected';
+
+      this.socket.emit('selectRoom', { room: 'next-race' }, (response?: { status?: string }) => {
+        if (response?.status && response.status !== 'Success') {
+          this.message = response.status;
+        }
+      });
+    });
+
+    this.socket.on('disconnect', () => {
+      this.connected = false;
+      this.message = 'Connection lost';
+    });
+
+    this.socket.on('next_session', (data: NextSessionPayload) => {
+      this.nextSession = data;
+    });
+  }
+
+  ngOnDestroy(): void {
+    if (this.socket) {
+      this.socket.disconnect();
+    }
+  }
+
+  getDriverCarPairs(): Array<{ driver: string; car: number | null }> {
+    if (!this.nextSession) {
+      return [];
+    }
+
+    return this.nextSession.drivers.map((driver, index) => ({
+      driver,
+      car: this.nextSession?.cars[index] ?? null,
+    }));
+  }
+}

--- a/frontend/app/src/app/screens/next-race/next-race.ts
+++ b/frontend/app/src/app/screens/next-race/next-race.ts
@@ -4,9 +4,8 @@ import { io, Socket } from 'socket.io-client';
 
 type NextSessionPayload = {
   sessionId: number;
-  drivers: string[];
-  cars: number[];
-  status: string;
+  driverNames: string[];
+  carNumbers: number[];
 };
 
 @Component({
@@ -27,23 +26,30 @@ export class NextRace implements OnInit, OnDestroy {
     this.socket = io();
 
     this.socket.on('connect', () => {
-      this.connected = true;
-      this.message = 'Connected';
-
       this.socket.emit('selectRoom', { room: 'next-race' }, (response?: { status?: string }) => {
-        if (response?.status && response.status !== 'Success') {
-          this.message = response.status;
+        if (response?.status === 'Success') {
+          this.connected = true;
+          this.message = 'Connected';
+        } else {
+          this.connected = false;
+          this.message = response?.status ?? 'Connection failed';
         }
-      });
+       }
+      );
     });
 
     this.socket.on('disconnect', () => {
       this.connected = false;
       this.message = 'Connection lost';
     });
-
-    this.socket.on('next_session', (data: NextSessionPayload) => {
-      this.nextSession = data;
+  
+    this.socket.on('nextSessionUpdate', (data: any) => {
+      if (data?.driverNames && data?.carNumbers) {
+        this.nextSession = data;
+      } else {
+        this.nextSession = null;
+        this.message = data?.message ?? 'No upcoming session available';
+      }
     });
   }
 
@@ -57,10 +63,12 @@ export class NextRace implements OnInit, OnDestroy {
     if (!this.nextSession) {
       return [];
     }
-
-    return this.nextSession.drivers.map((driver, index) => ({
+    return this.nextSession.driverNames.map((driver, index) => ({
       driver,
-      car: this.nextSession?.cars[index] ?? null,
+      car: this.nextSession?.carNumbers[index] ?? null,
     }));
+  }
+  enterFullscreen(): void {
+    document.documentElement.requestFullscreen();
   }
 }

--- a/frontend/app/src/app/screens/next-race/next-race.ts
+++ b/frontend/app/src/app/screens/next-race/next-race.ts
@@ -6,6 +6,8 @@ type NextSessionPayload = {
   sessionId: number;
   driverNames: string[];
   carNumbers: number[];
+  status?: string;
+  message?: string;
 };
 
 @Component({
@@ -43,13 +45,20 @@ export class NextRace implements OnInit, OnDestroy {
       this.message = 'Connection lost';
     });
   
-    this.socket.on('nextSessionUpdate', (data: any) => {
-      if (data?.driverNames && data?.carNumbers) {
+    this.socket.on('nextSessionUpdate', (data: unknown) => {
+      if (this.isNextSessionPayload(data)) {
         this.nextSession = data;
-      } else {
-        this.nextSession = null;
-        this.message = data?.message ?? 'No upcoming session available';
+        this.message = '';
+        return;
       }
+
+      if (data && typeof data === 'object' && 'message' in data) {
+        this.nextSession = null;
+        this.message = String((data as { message?: string }).message ?? 'No upcoming session available');
+        return;
+      }
+
+      this.message = 'Unexpected update received';
     });
   }
 
@@ -57,6 +66,16 @@ export class NextRace implements OnInit, OnDestroy {
     if (this.socket) {
       this.socket.disconnect();
     }
+  }
+
+  private isNextSessionPayload(data: unknown): data is NextSessionPayload {
+    return !!data
+      && typeof data === 'object'
+      && 'sessionId' in data
+      && 'driverNames' in data
+      && 'carNumbers' in data
+      && Array.isArray((data as NextSessionPayload).driverNames)
+      && Array.isArray((data as NextSessionPayload).carNumbers);
   }
 
   getDriverCarPairs(): Array<{ driver: string; car: number | null }> {


### PR DESCRIPTION
Implemented the "Next Race screen"

- Added standalone Angular component
- Connected to Socket.IO
- Joined `next-race` room via `selectRoom`
- Subscribed to `next_session` event
- Displayed sessionId, status, drivers and cars
- Implemented safe rendering when no data is available

Behavior

- Read-only screen (no client → server actions)
- Updates in real-time from server
- Shows fallback message if no upcoming session

Notes

- No authentication required for this screen
- Follows API docs for next race screen