### PR TITLE
feat Add grouped Home screen navigation

### DIFF
--- a/frontend/app/src/app/app.routes.ts
+++ b/frontend/app/src/app/app.routes.ts
@@ -6,9 +6,11 @@ import { LeaderBoard } from './screens/leader-board/leader-board';
 import { NextRace } from './screens/next-race/next-race';
 import { RaceCountdown } from './screens/race-countdown/race-countdown';
 import { RaceFlags } from './screens/race-flags/race-flags';
+import { Home } from './screens/home/home';
 
 export const routes: Routes = [
-  { path: '', redirectTo: 'next-race', pathMatch: 'full' },
+  { path: '', redirectTo: 'home', pathMatch: 'full' },
+  { path: 'home', component: Home },
   { path: 'front-desk', component: FrontDesk },
   { path: 'race-control', component: RaceControl },
   { path: 'lap-line-tracker', component: LapLineTracker },
@@ -16,5 +18,5 @@ export const routes: Routes = [
   { path: 'next-race', component: NextRace },
   { path: 'race-countdown', component: RaceCountdown },
   { path: 'race-flags', component: RaceFlags },
-  { path: '**', redirectTo: 'next-race' }
+  { path: '**', redirectTo: 'home' }
 ];

--- a/frontend/app/src/app/screens/home/home.html
+++ b/frontend/app/src/app/screens/home/home.html
@@ -1,0 +1,33 @@
+<main class="home-screen">
+  <section class="home-card">
+    <h1>Beachside Racetrack</h1>
+    <p class="intro">Choose a screen to open.</p>
+
+    <div class="groups">
+      <section class="screen-group secured">
+        <header>
+          <h2>Employee Screens</h2>
+          <p>Access key required</p>
+        </header>
+        <nav class="screen-grid" aria-label="Employee screen selection">
+          <a routerLink="/front-desk" class="screen-btn">Front Desk</a>
+          <a routerLink="/race-control" class="screen-btn">Race Control</a>
+          <a routerLink="/lap-line-tracker" class="screen-btn">Lap-line Tracker</a>
+        </nav>
+      </section>
+
+      <section class="screen-group public">
+        <header>
+          <h2>Public Displays</h2>
+          <p>No access key needed</p>
+        </header>
+        <nav class="screen-grid" aria-label="Public display selection">
+          <a routerLink="/leader-board" class="screen-btn">Leader Board</a>
+          <a routerLink="/next-race" class="screen-btn">Next Race</a>
+          <a routerLink="/race-countdown" class="screen-btn">Race Countdown</a>
+          <a routerLink="/race-flags" class="screen-btn">Race Flags</a>
+        </nav>
+      </section>
+    </div>
+  </section>
+</main>

--- a/frontend/app/src/app/screens/home/home.scss
+++ b/frontend/app/src/app/screens/home/home.scss
@@ -1,0 +1,126 @@
+.home-screen {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  background:
+    radial-gradient(circle at 15% 20%, #1db954 0%, transparent 35%),
+    radial-gradient(circle at 85% 80%, #f7c32e 0%, transparent 32%),
+    linear-gradient(145deg, #10202f 0%, #15283c 45%, #0d1a28 100%);
+  color: #f6f8fb;
+}
+
+.home-card {
+  width: min(980px, 100%);
+  padding: 2rem;
+  border-radius: 20px;
+  background: rgba(8, 16, 26, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.7rem, 2.3vw, 2.5rem);
+  letter-spacing: 0.03em;
+}
+
+.intro {
+  margin: 0.6rem 0 1.6rem;
+  color: #d9e4ef;
+}
+
+.groups {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+.screen-group {
+  padding: 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.screen-group header {
+  margin-bottom: 0.85rem;
+}
+
+.screen-group h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+}
+
+.screen-group p {
+  margin: 0.35rem 0 0;
+  font-size: 0.92rem;
+  color: #c3d3e3;
+}
+
+.screen-group.secured {
+  background: linear-gradient(180deg, rgba(243, 163, 74, 0.14), rgba(243, 163, 74, 0.06));
+  border-color: rgba(243, 163, 74, 0.34);
+}
+
+.screen-group.public {
+  background: linear-gradient(180deg, rgba(89, 174, 255, 0.14), rgba(89, 174, 255, 0.06));
+  border-color: rgba(89, 174, 255, 0.34);
+}
+
+.screen-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.85rem;
+}
+
+.screen-btn {
+  display: grid;
+  place-items: center;
+  min-height: 78px;
+  padding: 0.75rem;
+  border-radius: 14px;
+  text-decoration: none;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: #0f1f2e;
+  background: linear-gradient(135deg, #f7f8fa, #e5ecf3);
+  border: 1px solid rgba(16, 32, 48, 0.15);
+  transition: transform 140ms ease, box-shadow 140ms ease, background 160ms ease;
+}
+
+.screen-btn:hover,
+.screen-btn:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(11, 20, 32, 0.3);
+  background: linear-gradient(135deg, #ffffff, #ecf4ff);
+}
+
+.secured .screen-btn {
+  background: linear-gradient(135deg, #f8ecdc, #ffe2c0);
+}
+
+.secured .screen-btn:hover,
+.secured .screen-btn:focus-visible {
+  background: linear-gradient(135deg, #ffeed8, #ffd7a8);
+}
+
+.public .screen-btn {
+  background: linear-gradient(135deg, #e7f2ff, #d6e9ff);
+}
+
+.public .screen-btn:hover,
+.public .screen-btn:focus-visible {
+  background: linear-gradient(135deg, #f0f7ff, #cfe6ff);
+}
+
+@media (max-width: 600px) {
+  .home-card {
+    padding: 1.2rem;
+  }
+
+  .screen-btn {
+    min-height: 70px;
+  }
+}

--- a/frontend/app/src/app/screens/home/home.ts
+++ b/frontend/app/src/app/screens/home/home.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-home',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './home.html',
+  styleUrl: './home.scss',
+})
+export class Home {}


### PR DESCRIPTION
### Summary

- Add a new Home screen with navigation to all 7 app screens
- Split Home navigation into two visual groups:
  - Employee Screens (access key required)
  - Public Displays (no access key needed)
- Update router defaults so / and unknown paths redirect to /home

### Changes

- Updated routing in `app.routes.ts`
- Added Home component in `home.ts`
- Added Home template in `home.html`
- Added Home styles in `home.scss`

### UX Impact

- Cleaner entry point for operators and guests
- Faster screen selection with clearer role-based grouping
- Keeps large, touch-friendly navigation buttons

### Testing

- Verified Angular file-level diagnostics show no errors for changed files
- Manual check recommended:
  - Open /home
  - Confirm all 7 buttons navigate correctly
  - Confirm default route redirects to /home"