### PR TITLE
feat: Unify screen design and add global navbar shell

### DIFF
--- a/frontend/app/src/app/app.html
+++ b/frontend/app/src/app/app.html
@@ -1,1 +1,39 @@
-<router-outlet></router-outlet>
+<div class="app-shell">
+	<header class="top-nav">
+		<nav class="nav-group nav-left" aria-label="Authenticated screens">
+			<a
+				*ngFor="let item of authenticatedScreens"
+				class="nav-link"
+				[routerLink]="item.route"
+				routerLinkActive="active"
+			>
+				{{ item.label }}
+			</a>
+		</nav>
+
+		<a
+			class="home-link"
+			routerLink="/home"
+			routerLinkActive="active"
+			[routerLinkActiveOptions]="{ exact: true }"
+			aria-label="Go to Beachside Racetrack home"
+		>
+			Beachside Racetrack
+		</a>
+
+		<nav class="nav-group nav-right" aria-label="Public screens">
+			<a
+				*ngFor="let item of publicScreens"
+				class="nav-link"
+				[routerLink]="item.route"
+				routerLinkActive="active"
+			>
+				{{ item.label }}
+			</a>
+		</nav>
+	</header>
+
+	<main class="app-content">
+		<router-outlet></router-outlet>
+	</main>
+</div>

--- a/frontend/app/src/app/app.scss
+++ b/frontend/app/src/app/app.scss
@@ -1,0 +1,109 @@
+:host {
+	display: block;
+}
+
+.app-shell {
+	min-height: 100vh;
+	display: flex;
+	flex-direction: column;
+}
+
+.top-nav {
+	position: sticky;
+	top: 0;
+	z-index: 25;
+	display: grid;
+	grid-template-columns: 1fr minmax(220px, 340px) 1fr;
+	align-items: center;
+	gap: 0.85rem;
+	padding: 0.85rem 1rem;
+	background: rgba(7, 14, 22, 0.76);
+	border-bottom: 1px solid rgba(180, 204, 229, 0.18);
+	backdrop-filter: blur(10px);
+}
+
+.nav-group {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.nav-left {
+	justify-content: flex-start;
+}
+
+.nav-right {
+	justify-content: flex-end;
+}
+
+.nav-link,
+.home-link {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 38px;
+	padding: 0.45rem 0.95rem;
+	border-radius: 999px;
+	text-decoration: none;
+	font-weight: 700;
+	letter-spacing: 0.01em;
+	transition: background 160ms ease, color 160ms ease, transform 160ms ease;
+}
+
+.nav-link {
+	color: #dbe8f6;
+	border: 1px solid rgba(159, 193, 228, 0.2);
+	background: rgba(143, 179, 217, 0.12);
+	font-size: 0.88rem;
+}
+
+.home-link {
+	color: #0f1f2f;
+	border: 1px solid rgba(255, 255, 255, 0.15);
+	background: linear-gradient(135deg, #f7c32e 0%, #f6e07f 100%);
+	font-size: 1rem;
+	text-align: center;
+}
+
+.nav-link:hover,
+.home-link:hover,
+.nav-link:focus-visible,
+.home-link:focus-visible {
+	transform: translateY(-1px);
+}
+
+.nav-link.active {
+	color: #061320;
+	border-color: rgba(255, 255, 255, 0.34);
+	background: linear-gradient(135deg, #8fe8ff, #d3f5ff);
+}
+
+.home-link.active {
+	border-color: rgba(255, 255, 255, 0.48);
+	box-shadow: 0 8px 18px rgba(247, 195, 46, 0.3);
+}
+
+.app-content {
+	flex: 1;
+	width: min(1240px, 100%);
+	margin: 0 auto;
+	padding: 1.1rem;
+}
+
+@media (max-width: 1080px) {
+	.top-nav {
+		grid-template-columns: 1fr;
+	}
+
+	.home-link {
+		order: -1;
+		width: min(100%, 360px);
+		justify-self: center;
+	}
+
+	.nav-left,
+	.nav-right {
+		justify-content: center;
+	}
+}

--- a/frontend/app/src/app/app.ts
+++ b/frontend/app/src/app/app.ts
@@ -1,12 +1,24 @@
-import { Component, signal } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { Component } from '@angular/core';
+import { NgFor } from '@angular/common';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [NgFor, RouterOutlet, RouterLink, RouterLinkActive],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })
 export class App {
-  protected readonly title = signal('app');
+  readonly authenticatedScreens = [
+    { label: 'Front Desk', route: '/front-desk' },
+    { label: 'Race Control', route: '/race-control' },
+    { label: 'Lap-line Tracker', route: '/lap-line-tracker' },
+  ];
+
+  readonly publicScreens = [
+    { label: 'Next Race', route: '/next-race' },
+    { label: 'Race Countdown', route: '/race-countdown' },
+    { label: 'Race Flags', route: '/race-flags' },
+    { label: 'Leader Board', route: '/leader-board' },
+  ];
 }

--- a/frontend/app/src/app/screens/front-desk/front-desk.html
+++ b/frontend/app/src/app/screens/front-desk/front-desk.html
@@ -1,5 +1,6 @@
+<section class="screen-page front-desk-screen">
 <div class="auth-screen" *ngIf="!isAuthenticated">
-  <div class="auth-card">
+  <div class="screen-panel auth-card">
     <div class="auth-logo">
       <h1>Front Desk</h1>
       <p class="auth-subtitle">Reception Interface</p>
@@ -33,7 +34,7 @@
 </div>
 
 
-<div class="dashboard" *ngIf="isAuthenticated">
+<div class="screen-panel dashboard" *ngIf="isAuthenticated">
 
   <!-- Päis -->
   <header class="dashboard-header">
@@ -177,3 +178,4 @@
     </div>
   </div>
 </div>
+</section>

--- a/frontend/app/src/app/screens/front-desk/front-desk.scss
+++ b/frontend/app/src/app/screens/front-desk/front-desk.scss
@@ -1,0 +1,213 @@
+.front-desk-screen {
+	align-content: center;
+}
+
+.auth-screen {
+	display: grid;
+	place-items: center;
+}
+
+.auth-card {
+	width: min(520px, 100%);
+	display: grid;
+	gap: 1.2rem;
+}
+
+.auth-logo h1 {
+	margin: 0;
+}
+
+.auth-subtitle {
+	margin: 0.35rem 0 0;
+	color: #bfd4e8;
+}
+
+.auth-form {
+	display: grid;
+	gap: 0.65rem;
+}
+
+.field-label {
+	font-weight: 700;
+}
+
+.auth-error {
+	margin: 0;
+	color: #ff9eab;
+	font-weight: 600;
+}
+
+.spinner {
+	display: inline-flex;
+	align-items: center;
+}
+
+.dashboard {
+	display: grid;
+	gap: 1rem;
+}
+
+.dashboard-header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 1rem;
+}
+
+.header-title {
+	margin: 0;
+}
+
+.header-sub {
+	margin: 0.35rem 0 0;
+	color: #c6dcf2;
+}
+
+.header-right {
+	display: flex;
+	align-items: center;
+	gap: 0.6rem;
+}
+
+.session-count {
+	border-radius: 999px;
+	border: 1px solid rgba(178, 208, 237, 0.25);
+	background: rgba(175, 206, 236, 0.1);
+	padding: 0.35rem 0.72rem;
+	font-weight: 700;
+	color: #d7e8fa;
+}
+
+.empty-state {
+	border: 1px dashed rgba(182, 211, 240, 0.35);
+	border-radius: 14px;
+	padding: 1rem;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	align-items: center;
+	gap: 0.7rem;
+}
+
+.empty-state p {
+	margin: 0;
+}
+
+.sessions-list {
+	display: grid;
+	gap: 0.9rem;
+}
+
+.session-card {
+	border-radius: 16px;
+	border: 1px solid rgba(177, 208, 237, 0.2);
+	background: rgba(156, 196, 232, 0.07);
+	padding: 0.95rem;
+}
+
+.session-card.locked {
+	border-color: rgba(247, 195, 46, 0.36);
+	background: rgba(247, 195, 46, 0.09);
+}
+
+.session-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.65rem;
+}
+
+.session-title {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.45rem;
+}
+
+.session-number {
+	font-weight: 800;
+}
+
+.lock-badge,
+.driver-count {
+	padding: 0.2rem 0.55rem;
+	border-radius: 999px;
+	font-size: 0.8rem;
+	font-weight: 700;
+}
+
+.lock-badge {
+	color: #241604;
+	background: #f6d37d;
+}
+
+.driver-count {
+	color: #dbebfc;
+	background: rgba(173, 204, 235, 0.2);
+}
+
+.drivers-section {
+	margin-top: 0.8rem;
+	display: grid;
+	gap: 0.7rem;
+}
+
+.drivers-table .car-number {
+	width: 90px;
+}
+
+.car-badge {
+	min-width: 44px;
+	display: inline-flex;
+	justify-content: center;
+	border-radius: 999px;
+	background: rgba(143, 184, 224, 0.25);
+	padding: 0.2rem 0.55rem;
+	font-weight: 700;
+}
+
+.inline-input,
+.driver-input {
+	width: 100%;
+}
+
+.driver-actions,
+.add-driver-buttons {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.4rem;
+}
+
+.add-driver-form {
+	display: grid;
+	gap: 0.55rem;
+}
+
+.no-drivers,
+.max-notice {
+	margin: 0;
+	color: #c5dbf1;
+}
+
+.btn-full {
+	width: 100%;
+}
+
+.btn-sm {
+	padding: 0.45rem 0.8rem;
+	font-size: 0.9rem;
+}
+
+.btn-xs {
+	padding: 0.28rem 0.52rem;
+	font-size: 0.8rem;
+}
+
+@media (max-width: 860px) {
+	.dashboard-header,
+	.header-right,
+	.session-header {
+		flex-direction: column;
+		align-items: flex-start;
+	}
+}

--- a/frontend/app/src/app/screens/home/home.html
+++ b/frontend/app/src/app/screens/home/home.html
@@ -1,12 +1,12 @@
-<main class="home-screen">
-  <section class="home-card">
+<section class="screen-page home-screen">
+  <section class="screen-panel home-card">
     <h1>Beachside Racetrack</h1>
-    <p class="intro">Choose a screen to open.</p>
+    <p class="intro">Choose a screen from the grouped quick launcher below.</p>
 
     <div class="groups">
       <section class="screen-group secured">
         <header>
-          <h2>Employee Screens</h2>
+          <h2>Authenticated Screens</h2>
           <p>Access key required</p>
         </header>
         <nav class="screen-grid" aria-label="Employee screen selection">
@@ -22,12 +22,12 @@
           <p>No access key needed</p>
         </header>
         <nav class="screen-grid" aria-label="Public display selection">
-          <a routerLink="/leader-board" class="screen-btn">Leader Board</a>
           <a routerLink="/next-race" class="screen-btn">Next Race</a>
           <a routerLink="/race-countdown" class="screen-btn">Race Countdown</a>
           <a routerLink="/race-flags" class="screen-btn">Race Flags</a>
+          <a routerLink="/leader-board" class="screen-btn">Leader Board</a>
         </nav>
       </section>
     </div>
   </section>
-</main>
+</section>

--- a/frontend/app/src/app/screens/home/home.scss
+++ b/frontend/app/src/app/screens/home/home.scss
@@ -1,22 +1,10 @@
 .home-screen {
-  min-height: 100vh;
-  display: grid;
-  place-items: center;
-  padding: 1.5rem;
-  background:
-    radial-gradient(circle at 15% 20%, #1db954 0%, transparent 35%),
-    radial-gradient(circle at 85% 80%, #f7c32e 0%, transparent 32%),
-    linear-gradient(145deg, #10202f 0%, #15283c 45%, #0d1a28 100%);
-  color: #f6f8fb;
+  place-content: center;
 }
 
 .home-card {
   width: min(980px, 100%);
   padding: 2rem;
-  border-radius: 20px;
-  background: rgba(8, 16, 26, 0.82);
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
 }
 
 h1 {
@@ -39,8 +27,8 @@ h1 {
 .screen-group {
   padding: 1rem;
   border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(185, 211, 236, 0.18);
+  background: rgba(155, 191, 228, 0.07);
 }
 
 .screen-group header {
@@ -56,7 +44,7 @@ h1 {
 .screen-group p {
   margin: 0.35rem 0 0;
   font-size: 0.92rem;
-  color: #c3d3e3;
+  color: #c9ddf1;
 }
 
 .screen-group.secured {
@@ -87,7 +75,7 @@ h1 {
   color: #0f1f2e;
   background: linear-gradient(135deg, #f7f8fa, #e5ecf3);
   border: 1px solid rgba(16, 32, 48, 0.15);
-  transition: transform 140ms ease, box-shadow 140ms ease, background 160ms ease;
+  transition: transform 140ms ease, box-shadow 140ms ease, background 160ms ease, filter 140ms ease;
 }
 
 .screen-btn:hover,
@@ -95,6 +83,7 @@ h1 {
   transform: translateY(-2px);
   box-shadow: 0 12px 24px rgba(11, 20, 32, 0.3);
   background: linear-gradient(135deg, #ffffff, #ecf4ff);
+  filter: saturate(1.1);
 }
 
 .secured .screen-btn {

--- a/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.html
+++ b/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.html
@@ -1,51 +1,47 @@
-<section style="max-width: 980px; margin: 0 auto; padding: 1rem;">
-	<h1>Lap-line Tracker</h1>
+<section class="screen-page">
+  <article class="screen-panel lap-tracker">
+    <h1>Lap-line Tracker</h1>
+    <p class="screen-subtitle">Register laps quickly while the race is active or finished.</p>
 
-	<div *ngIf="!isAuthenticated" style="display: grid; gap: 0.75rem; max-width: 420px;">
-		<label for="accessKey">Access key</label>
-		<input
-			id="accessKey"
-			type="password"
-			[(ngModel)]="accessKey"
-			[disabled]="isConnecting"
-			(keydown.enter)="connect()"
-			placeholder="Enter lap-line access key"
-			style="padding: 0.75rem; font-size: 1rem;"
-		/>
-		<button
-			type="button"
-			(click)="connect()"
-			[disabled]="isConnecting || !accessKey.trim()"
-			style="padding: 0.75rem 1rem; font-size: 1rem;"
-		>
-			{{ isConnecting ? 'Connecting...' : 'Connect' }}
-		</button>
+    <div *ngIf="!isAuthenticated" class="auth-block">
+      <label for="accessKey">Access key</label>
+      <input
+        id="accessKey"
+        type="password"
+        [(ngModel)]="accessKey"
+        [disabled]="isConnecting"
+        (keydown.enter)="connect()"
+        placeholder="Enter lap-line access key"
+      />
+      <button class="btn btn-primary" type="button" (click)="connect()" [disabled]="isConnecting || !accessKey.trim()">
+        {{ isConnecting ? 'Connecting...' : 'Connect' }}
+      </button>
 
-		<p *ngIf="authError" style="color: #b00020; margin: 0;">{{ authError }}</p>
-	</div>
+      <p *ngIf="authError" class="error">{{ authError }}</p>
+    </div>
 
-	<div *ngIf="isAuthenticated" style="display: grid; gap: 1rem;">
-		<p style="margin: 0; font-weight: 600;">Session status: {{ sessionStatus }}</p>
-		<p style="margin: 0;">{{ statusMessage }}</p>
+    <div *ngIf="isAuthenticated" class="tracker-board">
+      <div class="status-grid">
+        <p class="status-chip"><strong>Session:</strong> {{ sessionStatus }}</p>
+        <p class="status-chip"><strong>Status:</strong> {{ statusMessage }}</p>
+      </div>
 
-		<div
-			style="display: grid; gap: 0.75rem; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));"
-			aria-label="Lap buttons"
-		>
-			<button
-				*ngFor="let carNumber of carNumbers; trackBy: trackByCarNumber"
-				type="button"
-				(click)="sendLap(carNumber)"
-				[disabled]="!canRecordLaps"
-				[attr.aria-label]="'Record lap for car ' + carNumber"
-				style="min-height: 96px; font-size: 1.5rem; font-weight: 700;"
-			>
-				Car {{ carNumber }}
-			</button>
-		</div>
+      <div class="lap-grid" aria-label="Lap buttons">
+        <button
+          *ngFor="let carNumber of carNumbers; trackBy: trackByCarNumber"
+          class="btn btn-secondary lap-btn"
+          type="button"
+          (click)="sendLap(carNumber)"
+          [disabled]="!canRecordLaps"
+          [attr.aria-label]="'Record lap for car ' + carNumber"
+        >
+          Car {{ carNumber }}
+        </button>
+      </div>
 
-		<p *ngIf="!canRecordLaps" style="margin: 0;">
-			Lap buttons are disabled until race status is active or finished.
-		</p>
-	</div>
+      <p *ngIf="!canRecordLaps" class="muted">
+        Lap buttons are disabled until race status is active or finished.
+      </p>
+    </div>
+  </article>
 </section>

--- a/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.scss
+++ b/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.scss
@@ -1,0 +1,32 @@
+.lap-tracker {
+	display: grid;
+	gap: 1rem;
+}
+
+.auth-block {
+	max-width: 420px;
+	display: grid;
+	gap: 0.65rem;
+}
+
+.tracker-board {
+	display: grid;
+	gap: 1rem;
+}
+
+.lap-grid {
+	display: grid;
+	gap: 0.75rem;
+	grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.lap-btn {
+	min-height: 92px;
+	font-size: 1.25rem;
+}
+
+.error {
+	margin: 0;
+	color: #ff9dac;
+	font-weight: 600;
+}

--- a/frontend/app/src/app/screens/leader-board/leader-board.html
+++ b/frontend/app/src/app/screens/leader-board/leader-board.html
@@ -1,36 +1,42 @@
-<div>
-  <button (click)="enterFullscreen()">Full Screen</button>
+<section class="screen-page">
+  <article class="screen-panel leaderboard-screen">
+    <div class="header-row">
+      <div>
+        <h1>Leaderboard</h1>
+        <p class="screen-subtitle">Live race ranking and best laps.</p>
+      </div>
+      <button class="btn btn-primary" (click)="enterFullscreen()">Full Screen</button>
+    </div>
 
-  <p *ngIf="connectionError">{{ connectionError }}</p>
+    <p class="error" *ngIf="connectionError">{{ connectionError }}</p>
 
-  <!-- Timer and flag status -->
-  <div>
-    <span>Time Remaining: {{ formatTime(remainingSeconds) }}</span>
-    <span> | Flag: {{ currentFlag ?? 'none' }}</span>
-    <span> | Status: {{ sessionStatus }}</span>
-  </div>
+    <div class="status-grid">
+      <p class="status-chip"><strong>Time:</strong> {{ formatTime(remainingSeconds) }}</p>
+      <p class="status-chip"><strong>Flag:</strong> {{ currentFlag ?? 'none' }}</p>
+      <p class="status-chip"><strong>Status:</strong> {{ sessionStatus }}</p>
+    </div>
 
-  <!-- Leaderboard table -->
-  <table *ngIf="entries.length > 0">
-    <thead>
-      <tr>
-        <th>Position</th>
-        <th>Car</th>
-        <th>Driver</th>
-        <th>Laps</th>
-        <th>Best Lap</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr *ngFor="let entry of sortedEntries; let i = index">
-        <td>{{ i + 1 }}</td>
-        <td>{{ entry.carNumber }}</td>
-        <td>{{ entry.driverName }}</td>
-        <td>{{ entry.completedLaps }}</td>
-        <td>{{ formatLapTime(entry.bestLapTime) }}</td>
-      </tr>
-    </tbody>
-  </table>
+    <table *ngIf="entries.length > 0">
+      <thead>
+        <tr>
+          <th>Position</th>
+          <th>Car</th>
+          <th>Driver</th>
+          <th>Laps</th>
+          <th>Best Lap</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let entry of sortedEntries; let i = index">
+          <td>{{ i + 1 }}</td>
+          <td>{{ entry.carNumber }}</td>
+          <td>{{ entry.driverName }}</td>
+          <td>{{ entry.completedLaps }}</td>
+          <td>{{ formatLapTime(entry.bestLapTime) }}</td>
+        </tr>
+      </tbody>
+    </table>
 
-  <p *ngIf="entries.length === 0">No active race session.</p>
-</div>
+    <p *ngIf="entries.length === 0" class="muted">No active race session.</p>
+  </article>
+</section>

--- a/frontend/app/src/app/screens/leader-board/leader-board.scss
+++ b/frontend/app/src/app/screens/leader-board/leader-board.scss
@@ -1,0 +1,24 @@
+.leaderboard-screen {
+	display: grid;
+	gap: 1rem;
+}
+
+.header-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+}
+
+.error {
+	margin: 0;
+	color: #ff9dac;
+	font-weight: 600;
+}
+
+@media (max-width: 720px) {
+	.header-row {
+		flex-direction: column;
+		align-items: flex-start;
+	}
+}

--- a/frontend/app/src/app/screens/next-race/next-race.html
+++ b/frontend/app/src/app/screens/next-race/next-race.html
@@ -1,35 +1,44 @@
-<p>next-race works!</p>
+<section class="screen-page">
+  <article class="screen-panel next-race">
+    <div class="header-row">
+      <div>
+        <h1>Next Race</h1>
+        <p class="screen-subtitle">Upcoming session and driver allocation.</p>
+      </div>
+      <button class="btn btn-primary" type="button" (click)="enterFullscreen()">Full Screen</button>
+    </div>
 
-<div class="next-race">
-  <button type="button" (click)="enterFullscreen()">Full Screen</button>
+    <div class="status-grid">
+      <p class="status-chip"><strong>Connection:</strong> {{ connected ? 'Connected' : 'Disconnected' }}</p>
+      <p class="status-chip"><strong>Message:</strong> {{ message || '-' }}</p>
+    </div>
 
-  <h1>Next Race</h1>
-  <p><strong>Connection:</strong> {{ connected ? 'Connected' : 'Disconnected' }}</p>
-  <p><strong>Message:</strong> {{ message }}</p>
+    <ng-container *ngIf="nextSession; else noSession">
+      <div class="status-grid">
+        <p class="status-chip"><strong>Session ID:</strong> {{ nextSession.sessionId }}</p>
+        <p class="status-chip" *ngIf="nextSession.status"><strong>Status:</strong> {{ nextSession.status }}</p>
+      </div>
 
-  <ng-container *ngIf="nextSession; else noSession">
-    <p><strong>Session ID:</strong> {{ nextSession.sessionId }}</p>
-    <p *ngIf="nextSession.status"><strong>Status:</strong> {{ nextSession.status }}</p>
+      <ng-container *ngIf="getDriverCarPairs().length > 0; else noDriversYet">
+        <h2>Drivers and cars</h2>
+        <ul class="driver-list">
+          <li *ngFor="let item of getDriverCarPairs()">
+            {{ item.driver }} - Car {{ item.car }}
+          </li>
+        </ul>
+      </ng-container>
 
-    <ng-container *ngIf="getDriverCarPairs().length > 0; else noDriversYet">
-      <h2>Drivers and cars</h2>
-      <ul>
-        <li *ngFor="let item of getDriverCarPairs()">
-          {{ item.driver }} — Car {{ item.car }}
-        </li>
-      </ul>
+      <ng-template #noDriversYet>
+        <p class="muted">No drivers have been assigned yet.</p>
+      </ng-template>
+
+      <p *ngIf="nextSession.status === 'ended'" class="ended-message">
+        Please proceed to the paddock.
+      </p>
     </ng-container>
 
-    <ng-template #noDriversYet>
-      <p>No drivers have been assigned yet.</p>
+    <ng-template #noSession>
+      <p class="muted">No upcoming session available.</p>
     </ng-template>
-
-    <p *ngIf="nextSession.status === 'ended'">
-      Please proceed to the paddock.
-    </p>
-  </ng-container>
-
-  <ng-template #noSession>
-    <p>No upcoming session available.</p>
-  </ng-template>
-</div>
+  </article>
+</section>

--- a/frontend/app/src/app/screens/next-race/next-race.scss
+++ b/frontend/app/src/app/screens/next-race/next-race.scss
@@ -1,3 +1,31 @@
 .next-race {
-  padding: 24px;
+  display: grid;
+  gap: 1rem;
+}
+
+.header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.driver-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.ended-message {
+  margin: 0;
+  color: #ffe09a;
+  font-weight: 700;
+}
+
+@media (max-width: 720px) {
+  .header-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }

--- a/frontend/app/src/app/screens/race-control/race-control.html
+++ b/frontend/app/src/app/screens/race-control/race-control.html
@@ -1,40 +1,45 @@
-<main>
-	<h1>Race Control</h1>
+<section class="screen-page race-control-screen">
+	<article class="screen-panel">
+		<h1>Race Control</h1>
+		<p class="screen-subtitle">Control race start, flag changes, and session end.</p>
 
-	<p>Connection: {{ connected ? 'Connected' : 'Not connected' }}</p>
-	<p>Session status: {{ sessionStatus }}</p>
-	<p>Current flag: {{ currentFlag || '-' }}</p>
-	<p>Message: {{ message || '-' }}</p>
+		<div class="status-grid">
+			<p class="status-chip"><strong>Connection:</strong> {{ connected ? 'Connected' : 'Not connected' }}</p>
+			<p class="status-chip"><strong>Session:</strong> {{ sessionStatus }}</p>
+			<p class="status-chip"><strong>Flag:</strong> {{ currentFlag || '-' }}</p>
+			<p class="status-chip"><strong>Message:</strong> {{ message || '-' }}</p>
+		</div>
 
-	<hr />
+		<section class="control-group">
+			<h2>Race</h2>
+			<button class="btn btn-primary" type="button" (click)="startRaceCountdown()" [disabled]="!canStartRace()">
+				Start Race
+			</button>
+		</section>
 
-	<section>
-		<h2>Race</h2>
-		<button type="button" (click)="startRaceCountdown()" [disabled]="!canStartRace()">
-			Start Race
-		</button>
-	</section>
+		<section class="control-group">
+			<h2>Flags</h2>
+			<div class="button-row">
+				<button class="btn btn-success" type="button" (click)="changeFlag('green')" [disabled]="!canUseFlags()">
+					Safe (Green)
+				</button>
+				<button class="btn btn-secondary" type="button" (click)="changeFlag('yellow')" [disabled]="!canUseFlags()">
+					Hazard (Yellow)
+				</button>
+				<button class="btn btn-danger" type="button" (click)="changeFlag('red')" [disabled]="!canUseFlags()">
+					Danger (Red)
+				</button>
+				<button class="btn btn-ghost" type="button" (click)="changeFlag('finish')" [disabled]="!canUseFlags()">
+					Finish (Chequered)
+				</button>
+			</div>
+		</section>
 
-	<section>
-		<h2>Flags</h2>
-		<button type="button" (click)="changeFlag('green')" [disabled]="!canUseFlags()">
-			Safe (Green)
-		</button>
-		<button type="button" (click)="changeFlag('yellow')" [disabled]="!canUseFlags()">
-			Hazard (Yellow)
-		</button>
-		<button type="button" (click)="changeFlag('red')" [disabled]="!canUseFlags()">
-			Danger (Red)
-		</button>
-		<button type="button" (click)="changeFlag('finish')" [disabled]="!canUseFlags()">
-			Finish (Chequered)
-		</button>
-	</section>
-
-	<section>
-		<h2>Session</h2>
-		<button type="button" (click)="endSession()" [disabled]="!canEndSession()">
-			End Session
-		</button>
-	</section>
-</main>
+		<section class="control-group">
+			<h2>Session</h2>
+			<button class="btn btn-danger" type="button" (click)="endSession()" [disabled]="!canEndSession()">
+				End Session
+			</button>
+		</section>
+	</article>
+</section>

--- a/frontend/app/src/app/screens/race-control/race-control.scss
+++ b/frontend/app/src/app/screens/race-control/race-control.scss
@@ -1,0 +1,15 @@
+.race-control-screen {
+	align-content: center;
+}
+
+.control-group {
+	padding-top: 0.9rem;
+	margin-top: 0.9rem;
+	border-top: 1px solid rgba(161, 194, 227, 0.17);
+}
+
+.button-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.55rem;
+}

--- a/frontend/app/src/app/screens/race-countdown/race-countdown.html
+++ b/frontend/app/src/app/screens/race-countdown/race-countdown.html
@@ -1,11 +1,21 @@
-<div class="countdown-screen">
-  <button class="fullscreen-btn" (click)="enterFullscreen()">Full Screen</button>
+<section class="screen-page countdown-page">
+  <article class="screen-panel countdown-screen">
+    <div class="header-row">
+      <div>
+        <h1>Race Countdown</h1>
+        <p class="screen-subtitle">Live pre-race countdown display.</p>
+      </div>
+      <button class="btn btn-primary" (click)="enterFullscreen()">Full Screen</button>
+    </div>
 
-  <ng-container *ngIf="countdown !== null; else idleState">
-    <h1 class="countdown-value">{{ countdown }}</h1>
-  </ng-container>
+    <div class="countdown-display">
+      <ng-container *ngIf="countdown !== null; else idleState">
+        <h2 class="countdown-value">{{ countdown }}</h2>
+      </ng-container>
 
-  <ng-template #idleState>
-    <p class="idle-message">Waiting for race start...</p>
-  </ng-template>
-</div>
+      <ng-template #idleState>
+        <p class="idle-message">Waiting for race start...</p>
+      </ng-template>
+    </div>
+  </article>
+</section>

--- a/frontend/app/src/app/screens/race-countdown/race-countdown.scss
+++ b/frontend/app/src/app/screens/race-countdown/race-countdown.scss
@@ -1,7 +1,40 @@
 .countdown-screen {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.header-row {
   display: flex;
-  justify-content: center;
   align-items: center;
-  height: 100vh;
-  font-size: 80px;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.countdown-display {
+  min-height: 320px;
+  display: grid;
+  place-items: center;
+  border-radius: 18px;
+  border: 1px solid rgba(177, 206, 234, 0.22);
+  background: rgba(145, 193, 241, 0.08);
+}
+
+.countdown-value {
+  margin: 0;
+  font-size: clamp(5rem, 12vw, 8.5rem);
+  line-height: 1;
+  color: #f7c32e;
+}
+
+.idle-message {
+  margin: 0;
+  color: #d8e8f8;
+  font-size: 1.3rem;
+}
+
+@media (max-width: 720px) {
+  .header-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }

--- a/frontend/app/src/app/screens/race-flags/race-flags.html
+++ b/frontend/app/src/app/screens/race-flags/race-flags.html
@@ -1,15 +1,25 @@
-<main>
-	<h1>Race Flags</h1>
+<section class="screen-page">
+	<article class="screen-panel race-flags-screen">
+		<div class="header-row">
+			<div>
+				<h1>Race Flags</h1>
+				<p class="screen-subtitle">Live track safety flag status for public display.</p>
+			</div>
+			<button class="btn btn-primary" type="button" (click)="enterFullscreen()">Full Screen</button>
+		</div>
 
-	<p>Connection: {{ connected ? 'Connected' : 'Not connected' }}</p>
-	<p>Message: {{ message || '-' }}</p>
+		<div class="status-grid">
+			<p class="status-chip"><strong>Connection:</strong> {{ connected ? 'Connected' : 'Not connected' }}</p>
+			<p class="status-chip"><strong>Message:</strong> {{ message || '-' }}</p>
+		</div>
 
-	<hr />
+		<section class="flag-panel">
+			<h2>Current Flag</h2>
+			<p *ngIf="currentFlag; else noFlag" class="flag-value" [attr.data-flag]="currentFlag">{{ currentFlag }}</p>
 
-	<h2>Current Flag</h2>
-	<p *ngIf="currentFlag; else noFlag">{{ currentFlag }}</p>
-
-	<ng-template #noFlag>
-		<p>No flag selected</p>
-	</ng-template>
-</main>
+			<ng-template #noFlag>
+				<p class="muted">No flag selected</p>
+			</ng-template>
+		</section>
+	</article>
+</section>

--- a/frontend/app/src/app/screens/race-flags/race-flags.scss
+++ b/frontend/app/src/app/screens/race-flags/race-flags.scss
@@ -1,0 +1,49 @@
+.race-flags-screen {
+	display: grid;
+	gap: 1rem;
+}
+
+.header-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+}
+
+.flag-panel {
+	border-radius: 16px;
+	border: 1px solid rgba(182, 212, 240, 0.2);
+	background: rgba(172, 203, 236, 0.08);
+	padding: 1rem;
+}
+
+.flag-value {
+	margin: 0;
+	font-size: clamp(2rem, 6vw, 3.4rem);
+	font-weight: 800;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+}
+
+.flag-value[data-flag='green'] {
+	color: #89f2ae;
+}
+
+.flag-value[data-flag='yellow'] {
+	color: #ffe27f;
+}
+
+.flag-value[data-flag='red'] {
+	color: #ff9aa8;
+}
+
+.flag-value[data-flag='finish'] {
+	color: #cde4ff;
+}
+
+@media (max-width: 720px) {
+	.header-row {
+		flex-direction: column;
+		align-items: flex-start;
+	}
+}

--- a/frontend/app/src/app/screens/race-flags/race-flags.ts
+++ b/frontend/app/src/app/screens/race-flags/race-flags.ts
@@ -45,4 +45,10 @@ export class RaceFlags implements OnInit, OnDestroy {
       this.socket.disconnect();
     }
   }
+
+  enterFullscreen(): void {
+    document.documentElement.requestFullscreen().catch((err) => {
+      console.warn('Fullscreen failed:', err);
+    });
+  }
 }

--- a/frontend/app/src/styles.scss
+++ b/frontend/app/src/styles.scss
@@ -1,1 +1,195 @@
-/* You can add global styles to this file, and also import other style files */
+@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700;800&display=swap');
+
+:root {
+	--text-main: #f2f7fc;
+	--text-soft: #bad0e5;
+	--panel-bg: rgba(8, 16, 26, 0.84);
+	--panel-border: rgba(177, 204, 230, 0.2);
+	--accent-blue: #8fe8ff;
+	--accent-gold: #f7c32e;
+	--danger: #ff7a7a;
+	--success: #7de1a7;
+}
+
+* {
+	box-sizing: border-box;
+}
+
+html,
+body {
+	min-height: 100%;
+}
+
+body {
+	margin: 0;
+	color: var(--text-main);
+	font-family: 'Manrope', 'Segoe UI', sans-serif;
+	background:
+		radial-gradient(circle at 15% 15%, #1db954 0%, transparent 34%),
+		radial-gradient(circle at 78% 18%, #3ca4ff 0%, transparent 35%),
+		radial-gradient(circle at 86% 86%, #f7c32e 0%, transparent 36%),
+		linear-gradient(155deg, #0a1624 0%, #102233 56%, #0d1a28 100%);
+	background-attachment: fixed;
+}
+
+h1,
+h2,
+h3,
+p {
+	margin-top: 0;
+}
+
+.screen-page {
+	min-height: calc(100vh - 110px);
+	display: grid;
+	align-content: start;
+	gap: 1rem;
+}
+
+.screen-panel {
+	border-radius: 20px;
+	border: 1px solid var(--panel-border);
+	background: var(--panel-bg);
+	box-shadow: 0 20px 45px rgba(0, 0, 0, 0.32);
+	padding: 1.4rem;
+}
+
+.screen-panel h1 {
+	margin-bottom: 0.45rem;
+	font-size: clamp(1.45rem, 2vw, 2.3rem);
+	letter-spacing: 0.02em;
+}
+
+.screen-panel h2 {
+	margin-bottom: 0.5rem;
+	font-size: 1.1rem;
+}
+
+.screen-subtitle {
+	margin: 0;
+	color: var(--text-soft);
+}
+
+.status-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+	gap: 0.65rem;
+	margin: 1rem 0;
+}
+
+.status-chip {
+	border-radius: 14px;
+	border: 1px solid rgba(155, 190, 223, 0.2);
+	background: rgba(180, 211, 239, 0.1);
+	padding: 0.65rem 0.8rem;
+	font-weight: 600;
+	color: #d7e8f9;
+}
+
+.status-chip strong {
+	color: #ffffff;
+}
+
+.btn {
+	border: 1px solid transparent;
+	border-radius: 12px;
+	padding: 0.58rem 0.95rem;
+	font-weight: 700;
+	font-family: inherit;
+	cursor: pointer;
+	transition: transform 150ms ease, filter 150ms ease;
+}
+
+.btn:hover:not(:disabled),
+.btn:focus-visible:not(:disabled) {
+	transform: translateY(-1px);
+	filter: brightness(1.04);
+}
+
+.btn:disabled {
+	opacity: 0.56;
+	cursor: not-allowed;
+}
+
+.btn-primary {
+	color: #0b1a2a;
+	background: linear-gradient(135deg, #a3ecff, #d4f5ff);
+	border-color: rgba(255, 255, 255, 0.36);
+}
+
+.btn-secondary {
+	color: #0f1e2f;
+	background: linear-gradient(135deg, #f8ecdc, #ffe2b7);
+	border-color: rgba(255, 255, 255, 0.34);
+}
+
+.btn-success {
+	color: #0a2619;
+	background: linear-gradient(135deg, #a4f3c2, #d5ffe4);
+	border-color: rgba(255, 255, 255, 0.34);
+}
+
+.btn-danger {
+	color: #3a0f17;
+	background: linear-gradient(135deg, #ffb4c0, #ffd4dc);
+	border-color: rgba(255, 255, 255, 0.34);
+}
+
+.btn-ghost {
+	color: #dbe9f8;
+	background: rgba(186, 211, 235, 0.12);
+	border-color: rgba(186, 211, 235, 0.26);
+}
+
+input,
+button,
+textarea,
+select {
+	font: inherit;
+}
+
+input {
+	border-radius: 10px;
+	border: 1px solid rgba(178, 207, 236, 0.25);
+	background: rgba(8, 15, 24, 0.5);
+	color: #e8f3ff;
+	padding: 0.56rem 0.7rem;
+}
+
+input::placeholder {
+	color: #a6bfda;
+}
+
+table {
+	width: 100%;
+	border-collapse: collapse;
+	background: rgba(9, 17, 27, 0.44);
+	border-radius: 14px;
+	overflow: hidden;
+}
+
+th,
+td {
+	padding: 0.68rem;
+	text-align: left;
+	border-bottom: 1px solid rgba(157, 190, 223, 0.15);
+}
+
+th {
+	color: #daebff;
+	background: rgba(168, 199, 229, 0.13);
+}
+
+.muted {
+	color: var(--text-soft);
+}
+
+@media (max-width: 720px) {
+	.screen-panel {
+		padding: 1rem;
+	}
+
+	.status-grid {
+		grid-template-columns: 1fr;
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "info-screens",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
This PR introduces a shared UI shell and global styling so every screen has a consistent Beachside Racetrack design. It also adds a grouped top navbar to improve navigation between authenticated and public screens.

### Why:
The app had mixed styling approaches across routes, including unstyled pages and inline styles. This made navigation and visual consistency weaker. The task also requires fullscreen support on all public display screens.

### What changed:

- Added global app shell with top navbar:
  - Left: authenticated screens
  - Center: Beachside Racetrack home button
  - Right: public screens
- Moved theme and reusable UI primitives to global styles:
  - background, typography, cards, status chips, buttons, inputs, tables
- Refactored all screens to use shared layout/classes for consistent UI
- Added fullscreen button and fullscreen handler to Race Flags screen
- Kept existing screen behavior and Socket.IO data flow intact

### Testing:

- Frontend build passes successfully
- Manual checks completed for:
  - route navigation
  - responsive navbar behavior
  - fullscreen actions on public screens