### PR TITLE
FE: Align race UI with test requirements

### DIFF
--- a/frontend/app/src/app/screens/front-desk/front-desk.html
+++ b/frontend/app/src/app/screens/front-desk/front-desk.html
@@ -95,7 +95,18 @@
           <tbody>
             <tr *ngFor="let driver of getDrivers(session)">
               <td class="car-number">
-                <span class="car-badge">{{ driver.carNumber }}</span>
+                <span class="car-badge" *ngIf="isLocked(session)">{{ driver.carNumber }}</span>
+                <select
+                  *ngIf="!isLocked(session)"
+                  class="car-select"
+                  [ngModel]="driver.carNumber"
+                  (ngModelChange)="changeDriverCar(session.sessionId, driver.driverName, $event)"
+                  [attr.aria-label]="'Assign car for ' + driver.driverName"
+                >
+                  <option *ngFor="let car of getAvailableCars(session, driver.carNumber)" [ngValue]="car">
+                    {{ car }}
+                  </option>
+                </select>
               </td>
 
               <td *ngIf="isEditing(session.sessionId, driver.driverName)">

--- a/frontend/app/src/app/screens/front-desk/front-desk.scss
+++ b/frontend/app/src/app/screens/front-desk/front-desk.scss
@@ -166,6 +166,16 @@
 	font-weight: 700;
 }
 
+.car-select {
+	width: 100%;
+	min-width: 70px;
+	border-radius: 10px;
+	border: 1px solid rgba(178, 207, 236, 0.25);
+	background: rgba(8, 15, 24, 0.5);
+	color: #e8f3ff;
+	padding: 0.35rem 0.45rem;
+}
+
 .inline-input,
 .driver-input {
 	width: 100%;

--- a/frontend/app/src/app/screens/front-desk/front-desk.ts
+++ b/frontend/app/src/app/screens/front-desk/front-desk.ts
@@ -198,6 +198,40 @@ export class FrontDeskComponent implements OnInit, OnDestroy {
     delete this.newDriverNames[sessionId];
   }
 
+  changeDriverCar(sessionId: number, driverName: string, carNumber: number): void {
+    if (!Number.isInteger(carNumber) || carNumber < 1 || carNumber > 8) {
+      return;
+    }
+
+    const session = this.sessions.find((item) => item.sessionId === sessionId);
+    if (!session) {
+      return;
+    }
+
+    const currentIndex = session.driverNames.findIndex((name) => name === driverName);
+    if (currentIndex === -1) {
+      return;
+    }
+
+    const currentCar = session.carNumbers[currentIndex];
+    if (currentCar === carNumber) {
+      return;
+    }
+
+    const isTaken = session.carNumbers.some((assignedCar, index) => assignedCar === carNumber && index !== currentIndex);
+    if (isTaken) {
+      return;
+    }
+
+    session.carNumbers[currentIndex] = carNumber;
+
+    this.socket.emit('driverCarEdited', {
+      sessionId,
+      driverName,
+      carNumber
+    });
+  }
+
   startEdit(sessionId: number, driverName: string): void {
     this.editingDriver = { sessionId, driverName };
     this.editingNewName = driverName;
@@ -252,6 +286,19 @@ export class FrontDeskComponent implements OnInit, OnDestroy {
 
   canAddDriver(session: Session): boolean {
     return session.driverNames.length < 8 && !this.isLocked(session);
+  }
+
+  getAvailableCars(session: Session, currentCar: number): number[] {
+    const usedCars = new Set(session.carNumbers.filter((carNumber) => carNumber !== currentCar));
+    const options: number[] = [];
+
+    for (let car = 1; car <= 8; car++) {
+      if (!usedCars.has(car)) {
+        options.push(car);
+      }
+    }
+
+    return options;
   }
 
   onKeyDown(event: KeyboardEvent, action: 'addDriver' | 'confirmEdit', sessionId?: number): void {

--- a/frontend/app/src/app/screens/front-desk/front-desk.ts
+++ b/frontend/app/src/app/screens/front-desk/front-desk.ts
@@ -81,12 +81,12 @@ export class FrontDeskComponent implements OnInit, OnDestroy {
       this.cdr.detectChanges();
     });
 
-    this.socket.on('sessionsUpdated', (data: { sessions: Session[] }) => {
-      const activeSessionIds = new Set(data.sessions.map((session) => session.sessionId));
+    this.socket.on('sessionsUpdated', (sessions: Session[]) => {
+      const activeSessionIds = new Set(sessions.map((session) => session.sessionId));
       this.pruneLockedSessionIds(activeSessionIds);
       this.pruneNewDriverNames(activeSessionIds);
       this.clearStaleUiState(activeSessionIds);
-      this.sessions = data.sessions.map(session => ({
+      this.sessions = sessions.map(session => ({
         ...session,
         locked: session.locked === true || this.lockedSessionIds.has(session.sessionId)
       }));

--- a/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.html
+++ b/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.html
@@ -1,32 +1,41 @@
-<section class="screen-page">
-  <article class="screen-panel lap-tracker">
+<section class="screen-page lap-line-tracker-screen">
+  <div class="auth-screen" *ngIf="!isAuthenticated">
+    <article class="screen-panel auth-card">
+      <div class="auth-logo">
+        <h1>Lap-line Tracker</h1>
+        <p class="auth-subtitle">Register laps quickly while the race is active or finished.</p>
+      </div>
+
+      <div class="auth-block">
+        <label class="field-label" for="accessKey">Access key</label>
+        <input
+          id="accessKey"
+          type="password"
+          [(ngModel)]="accessKey"
+          [disabled]="isConnecting"
+          (keydown.enter)="connect()"
+          placeholder="Enter lap-line access key"
+        />
+        <button class="btn btn-primary btn-full" type="button" (click)="connect()" [disabled]="isConnecting || !accessKey.trim()">
+          {{ isConnecting ? 'Connecting...' : 'Connect' }}
+        </button>
+
+        <p *ngIf="authError" class="auth-error">{{ authError }}</p>
+      </div>
+    </article>
+  </div>
+
+  <article class="screen-panel lap-tracker" *ngIf="isAuthenticated">
     <h1>Lap-line Tracker</h1>
     <p class="screen-subtitle">Register laps quickly while the race is active or finished.</p>
 
-    <div *ngIf="!isAuthenticated" class="auth-block">
-      <label for="accessKey">Access key</label>
-      <input
-        id="accessKey"
-        type="password"
-        [(ngModel)]="accessKey"
-        [disabled]="isConnecting"
-        (keydown.enter)="connect()"
-        placeholder="Enter lap-line access key"
-      />
-      <button class="btn btn-primary" type="button" (click)="connect()" [disabled]="isConnecting || !accessKey.trim()">
-        {{ isConnecting ? 'Connecting...' : 'Connect' }}
-      </button>
-
-      <p *ngIf="authError" class="error">{{ authError }}</p>
-    </div>
-
-    <div *ngIf="isAuthenticated" class="tracker-board">
+    <div class="tracker-board">
       <div class="status-grid">
         <p class="status-chip"><strong>Session:</strong> {{ sessionStatus }}</p>
         <p class="status-chip"><strong>Status:</strong> {{ statusMessage }}</p>
       </div>
 
-      <div class="lap-grid" aria-label="Lap buttons">
+      <div class="lap-grid" aria-label="Lap buttons" *ngIf="carNumbers.length > 0; else noCars">
         <button
           *ngFor="let carNumber of carNumbers; trackBy: trackByCarNumber"
           class="btn btn-secondary lap-btn"
@@ -42,6 +51,10 @@
       <p *ngIf="!canRecordLaps" class="muted">
         Lap buttons are disabled until race status is active or finished.
       </p>
+
+      <ng-template #noCars>
+        <p class="muted">No active cars available yet for this session.</p>
+      </ng-template>
     </div>
   </article>
 </section>

--- a/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.scss
+++ b/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.scss
@@ -1,12 +1,43 @@
+.lap-line-tracker-screen {
+	align-content: center;
+}
+
+.auth-screen {
+	display: grid;
+	place-items: center;
+}
+
+.auth-card {
+	width: min(520px, 100%);
+	display: grid;
+	gap: 1.2rem;
+}
+
+.auth-logo h1 {
+	margin: 0;
+}
+
+.auth-subtitle {
+	margin: 0.35rem 0 0;
+	color: #bfd4e8;
+}
+
 .lap-tracker {
 	display: grid;
 	gap: 1rem;
 }
 
 .auth-block {
-	max-width: 420px;
 	display: grid;
 	gap: 0.65rem;
+}
+
+.field-label {
+	font-weight: 700;
+}
+
+.btn-full {
+	width: 100%;
 }
 
 .tracker-board {
@@ -25,8 +56,8 @@
 	font-size: 1.25rem;
 }
 
-.error {
+.auth-error {
 	margin: 0;
-	color: #ff9dac;
+	color: #ff9eab;
 	font-weight: 600;
 }

--- a/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.ts
+++ b/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.ts
@@ -5,6 +5,12 @@ import { io, Socket } from 'socket.io-client';
 
 type SessionStatus = 'notStarted' | 'active' | 'finished';
 
+type SessionUpdatePayload = {
+  sessionId: number;
+  driverNames: string[];
+  carNumbers: number[];
+};
+
 @Component({
   selector: 'app-lap-line-tracker',
   standalone: true,
@@ -15,7 +21,7 @@ type SessionStatus = 'notStarted' | 'active' | 'finished';
 export class LapLineTracker implements OnInit, OnDestroy {
   private socket!: Socket;
 
-  readonly carNumbers = [1, 2, 3, 4, 5, 6, 7, 8];
+  carNumbers: number[] = [];
 
   accessKey = '';
   isAuthenticated = false;
@@ -72,6 +78,14 @@ export class LapLineTracker implements OnInit, OnDestroy {
       }
 
       this.statusMessage = 'Waiting for race start.';
+    });
+
+    this.socket.on('sessionUpdate', (args: SessionUpdatePayload) => {
+      this.applyCarNumbers(args.carNumbers);
+    });
+
+    this.socket.on('lapTimes', (args: { carNumbers: number[] }) => {
+      this.applyCarNumbers(args.carNumbers);
     });
   }
 
@@ -136,5 +150,16 @@ export class LapLineTracker implements OnInit, OnDestroy {
         this.socket.disconnect();
       }
     );
+  }
+
+  private applyCarNumbers(carNumbers: number[]): void {
+    if (!Array.isArray(carNumbers)) {
+      return;
+    }
+
+    const normalized = carNumbers
+      .filter((value, index, source) => Number.isInteger(value) && value > 0 && source.indexOf(value) === index);
+
+    this.carNumbers = normalized;
   }
 }

--- a/frontend/app/src/app/screens/leader-board/leader-board.ts
+++ b/frontend/app/src/app/screens/leader-board/leader-board.ts
@@ -12,6 +12,12 @@ interface LeaderboardEntry {
   bestLapTime: number; // milliseconds, 0 = no lap yet
 }
 
+type SessionUpdatePayload = {
+  sessionId: number;
+  driverNames: string[];
+  carNumbers: number[];
+};
+
 @Component({
   selector: 'app-leader-board',
   standalone: true,
@@ -51,12 +57,17 @@ export class LeaderBoard implements OnInit, OnDestroy {
     });
 
     this.socket.on('sessionUpdate', (args: { sessionId: number; driverNames: string[]; carNumbers: number[] }) => {
-      this.entries = args.carNumbers.map((carNumber, i) => ({
-        carNumber,
-        driverName: args.driverNames[i],
-        completedLaps: 0,
-        bestLapTime: 0,
-      }));
+      this.syncSessionEntries(args);
+    });
+
+    this.socket.on('nextSessionUpdate', (args: unknown) => {
+      if (!this.isSessionUpdatePayload(args)) {
+        return;
+      }
+
+      if (this.sessionStatus === 'notStarted') {
+        this.syncSessionEntries(args);
+      }
     });
 
     this.socket.on('sessionStatus', (args: { status: SessionStatus }) => {
@@ -69,11 +80,20 @@ export class LeaderBoard implements OnInit, OnDestroy {
 
     this.socket.on('lapTimes', (args: { carNumbers: number[]; completedLaps: number[]; bestLapTime: number[] }) => {
       args.carNumbers.forEach((carNumber, i) => {
-        const entry = this.entries.find(e => e.carNumber === carNumber);
-        if (entry) {
-          entry.completedLaps = args.completedLaps[i];
-          entry.bestLapTime = args.bestLapTime[i];
+        let entry = this.entries.find(e => e.carNumber === carNumber);
+
+        if (!entry) {
+          entry = {
+            carNumber,
+            driverName: `Car ${carNumber}`,
+            completedLaps: 0,
+            bestLapTime: 0,
+          };
+          this.entries.push(entry);
         }
+
+        entry.completedLaps = args.completedLaps[i] ?? entry.completedLaps;
+        entry.bestLapTime = args.bestLapTime[i] ?? entry.bestLapTime;
       });
     });
 
@@ -100,6 +120,28 @@ export class LeaderBoard implements OnInit, OnDestroy {
     const m = Math.floor(totalSeconds / 60);
     const s = totalSeconds % 60;
     return `${m}:${String(s).padStart(2, '0')}`;
+  }
+
+  private syncSessionEntries(args: SessionUpdatePayload): void {
+    this.entries = args.carNumbers.map((carNumber, i) => {
+      const previous = this.entries.find((entry) => entry.carNumber === carNumber);
+      return {
+        carNumber,
+        driverName: args.driverNames[i] ?? `Car ${carNumber}`,
+        completedLaps: previous?.completedLaps ?? 0,
+        bestLapTime: previous?.bestLapTime ?? 0,
+      };
+    });
+  }
+
+  private isSessionUpdatePayload(data: unknown): data is SessionUpdatePayload {
+    return !!data
+      && typeof data === 'object'
+      && 'sessionId' in data
+      && 'driverNames' in data
+      && 'carNumbers' in data
+      && Array.isArray((data as SessionUpdatePayload).driverNames)
+      && Array.isArray((data as SessionUpdatePayload).carNumbers);
   }
 
   enterFullscreen(): void {

--- a/frontend/app/src/app/screens/next-race/next-race.html
+++ b/frontend/app/src/app/screens/next-race/next-race.html
@@ -32,7 +32,7 @@
         <p class="muted">No drivers have been assigned yet.</p>
       </ng-template>
 
-      <p *ngIf="nextSession.status === 'ended'" class="ended-message">
+      <p *ngIf="showPaddockPrompt" class="ended-message">
         Please proceed to the paddock.
       </p>
     </ng-container>

--- a/frontend/app/src/app/screens/next-race/next-race.ts
+++ b/frontend/app/src/app/screens/next-race/next-race.ts
@@ -23,6 +23,8 @@ export class NextRace implements OnInit, OnDestroy {
   connected = false;
   message = '';
   nextSession: NextSessionPayload | null = null;
+  showPaddockPrompt = false;
+  private hasRaceProgressed = false;
 
   ngOnInit(): void {
     this.socket = io();
@@ -44,11 +46,35 @@ export class NextRace implements OnInit, OnDestroy {
       this.connected = false;
       this.message = 'Connection lost';
     });
+
+    this.socket.on('sessionStatus', (args: { status: 'notStarted' | 'active' | 'finished' }) => {
+      if (args.status === 'active' || args.status === 'finished') {
+        this.hasRaceProgressed = true;
+      }
+
+      if (args.status === 'active') {
+        this.showPaddockPrompt = false;
+        return;
+      }
+
+      if (args.status === 'notStarted' && this.hasRaceProgressed) {
+        this.showPaddockPrompt = true;
+      }
+    });
+
+    this.socket.on('sessionEnded', () => {
+      this.showPaddockPrompt = true;
+    });
   
     this.socket.on('nextSessionUpdate', (data: unknown) => {
       if (this.isNextSessionPayload(data)) {
         this.nextSession = data;
         this.message = '';
+
+        if (data.status === 'ended') {
+          this.showPaddockPrompt = true;
+        }
+
         return;
       }
 

--- a/frontend/app/src/app/screens/race-control/race-control.html
+++ b/frontend/app/src/app/screens/race-control/race-control.html
@@ -1,5 +1,31 @@
 <section class="screen-page race-control-screen">
-	<article class="screen-panel">
+	<div class="auth-screen" *ngIf="!connected">
+		<article class="screen-panel auth-card">
+			<div class="auth-logo">
+				<h1>Race Control</h1>
+				<p class="screen-subtitle">Safety official access required.</p>
+			</div>
+
+			<div class="auth-block">
+				<label for="raceControlAccessKey">Access key</label>
+				<input
+					id="raceControlAccessKey"
+					type="password"
+					[(ngModel)]="accessKey"
+					[disabled]="isConnecting"
+					(keydown.enter)="connect()"
+					placeholder="Enter safety access key"
+				/>
+				<button class="btn btn-primary btn-full" type="button" (click)="connect()" [disabled]="isConnecting || !accessKey.trim()">
+					{{ isConnecting ? 'Connecting...' : 'Connect' }}
+				</button>
+
+				<p *ngIf="authError" class="error">{{ authError }}</p>
+			</div>
+		</article>
+	</div>
+
+	<article class="screen-panel" *ngIf="connected">
 		<h1>Race Control</h1>
 		<p class="screen-subtitle">Control race start, flag changes, and session end.</p>
 
@@ -10,14 +36,14 @@
 			<p class="status-chip"><strong>Message:</strong> {{ message || '-' }}</p>
 		</div>
 
-		<section class="control-group">
+		<section class="control-group" *ngIf="showRaceControls()">
 			<h2>Race</h2>
 			<button class="btn btn-primary" type="button" (click)="startRaceCountdown()" [disabled]="!canStartRace()">
 				Start Race
 			</button>
 		</section>
 
-		<section class="control-group">
+		<section class="control-group" *ngIf="showRaceControls()">
 			<h2>Flags</h2>
 			<div class="button-row">
 				<button class="btn btn-success" type="button" (click)="changeFlag('green')" [disabled]="!canUseFlags()">
@@ -35,11 +61,14 @@
 			</div>
 		</section>
 
-		<section class="control-group">
+		<section class="control-group" *ngIf="showEndSessionButton()">
 			<h2>Session</h2>
+			<p class="session-ready">Race is in Finish mode. End the session when all cars are in pit lane.</p>
 			<button class="btn btn-danger" type="button" (click)="endSession()" [disabled]="!canEndSession()">
 				End Session
 			</button>
 		</section>
+
+		<p class="muted" *ngIf="nextSessionMessage">{{ nextSessionMessage }}</p>
 	</article>
 </section>

--- a/frontend/app/src/app/screens/race-control/race-control.scss
+++ b/frontend/app/src/app/screens/race-control/race-control.scss
@@ -2,6 +2,40 @@
 	align-content: center;
 }
 
+.auth-screen {
+	display: grid;
+	place-items: center;
+}
+
+.auth-card {
+	width: min(520px, 100%);
+	display: grid;
+	gap: 1.2rem;
+}
+
+.auth-logo h1 {
+	margin: 0;
+}
+
+.auth-logo .screen-subtitle {
+	margin: 0.35rem 0 0;
+}
+
+.auth-block {
+	display: grid;
+	gap: 0.65rem;
+}
+
+.btn-full {
+	width: 100%;
+}
+
+.error {
+	margin: 0;
+	color: #ff9dac;
+	font-weight: 600;
+}
+
 .control-group {
 	padding-top: 0.9rem;
 	margin-top: 0.9rem;
@@ -12,4 +46,9 @@
 	display: flex;
 	flex-wrap: wrap;
 	gap: 0.55rem;
+}
+
+.session-ready {
+	margin: 0 0 0.7rem;
+	color: #d4e7fa;
 }

--- a/frontend/app/src/app/screens/race-control/race-control.ts
+++ b/frontend/app/src/app/screens/race-control/race-control.ts
@@ -1,14 +1,22 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { io, Socket } from 'socket.io-client';
 
 type SessionStatus = 'notStarted' | 'active' | 'finished';
 type RaceFlag = 'green' | 'yellow' | 'red' | 'finish';
 
+type NextSessionPayload = {
+  sessionId: number;
+  driverNames: string[];
+  carNumbers: number[];
+  message?: string;
+};
+
 @Component({
   selector: 'app-race-control',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, FormsModule],
   templateUrl: './race-control.html',
   styleUrls: ['./race-control.scss'],
 })
@@ -19,32 +27,31 @@ export class RaceControl implements OnInit, OnDestroy {
   sessionStatus: SessionStatus = 'notStarted';
   currentFlag: RaceFlag | '' = '';
   message = '';
+  authError = '';
+  isConnecting = false;
+  nextSessionMessage = '';
 
   accessKey = '';
 
   ngOnInit(): void {
-    this.accessKey = prompt('Enter access key') ?? '';
-    this.socket = io();
+    this.socket = io({ autoConnect: false, reconnection: true });
 
     this.socket.on('connect', () => {
-      this.socket.emit('selectRoom', { room: 'race-control', key: this.accessKey },
-      (response: { status: string }) => {
-        if (response.status === 'Success') {
-          this.connected = true;
-          this.message = 'Connected';
-        } else if (response.status === 'Invalid Access Key') {
-          this.connected = false;
-          this.message = 'Invalid Access Key';
-        } else {
-          this.connected = false;
-          this.message = response?.status ?? 'Connection failed';
-      }
-     }
-    );
-  });
+      this.joinRaceControlRoom();
+    });
+
     this.socket.on('disconnect', () => {
       this.connected = false;
-      this.message = 'Connection lost';
+      if (this.accessKey.trim()) {
+        this.message = 'Connection lost';
+      }
+    });
+
+    this.socket.on('connect_error', () => {
+      this.connected = false;
+      this.isConnecting = false;
+      this.authError = 'Unable to connect to server.';
+      this.message = 'Authentication required.';
     });
 
     this.socket.on('sessionStatus', (args: { status: SessionStatus }) => {
@@ -54,6 +61,34 @@ export class RaceControl implements OnInit, OnDestroy {
     this.socket.on('flagChanged', (args: { flag: RaceFlag }) => {
       this.currentFlag = args.flag;
     });
+
+    this.socket.on('nextSessionUpdate', (data: unknown) => {
+      if (this.isNextSessionPayload(data)) {
+        this.nextSessionMessage = '';
+        return;
+      }
+
+      if (data && typeof data === 'object' && 'message' in data) {
+        this.nextSessionMessage = String((data as { message?: string }).message ?? 'No upcoming races');
+      }
+    });
+  }
+
+  connect(): void {
+    if (!this.accessKey.trim() || this.isConnecting) {
+      return;
+    }
+
+    this.isConnecting = true;
+    this.authError = '';
+    this.message = 'Connecting...';
+
+    if (this.socket.connected) {
+      this.joinRaceControlRoom();
+      return;
+    }
+
+    this.socket.connect();
   }
 
   startRaceCountdown(): void {
@@ -94,12 +129,54 @@ export class RaceControl implements OnInit, OnDestroy {
   }
 
   canEndSession(): boolean {
-    return this.connected && this.sessionStatus !== 'notStarted';
+    return this.connected && this.sessionStatus === 'finished';
   }
 
-ngOnDestroy(): void {
-  if (this.socket) {
-    this.socket.disconnect();
+  showRaceControls(): boolean {
+    return this.connected && this.sessionStatus !== 'finished';
+  }
+
+  showEndSessionButton(): boolean {
+    return this.connected && this.sessionStatus === 'finished';
+  }
+
+  private isNextSessionPayload(data: unknown): data is NextSessionPayload {
+    return !!data
+      && typeof data === 'object'
+      && 'sessionId' in data
+      && 'driverNames' in data
+      && 'carNumbers' in data
+      && Array.isArray((data as NextSessionPayload).driverNames)
+      && Array.isArray((data as NextSessionPayload).carNumbers);
+  }
+
+  private joinRaceControlRoom(): void {
+    this.socket.emit(
+      'selectRoom',
+      { room: 'race-control', key: this.accessKey },
+      (response: { status: string }) => {
+        this.isConnecting = false;
+
+        if (response?.status === 'Success') {
+          this.connected = true;
+          this.authError = '';
+          this.message = 'Connected';
+          return;
+        }
+
+        this.connected = false;
+        this.authError = response?.status === 'Invalid Access Key'
+          ? 'Invalid access key. Please try again.'
+          : (response?.status ?? 'Authentication failed.');
+        this.message = 'Authentication required.';
+        this.socket.disconnect();
+      }
+    );
+  }
+
+  ngOnDestroy(): void {
+    if (this.socket) {
+      this.socket.disconnect();
     }
   }
 }

--- a/frontend/app/src/app/screens/race-flags/race-flags.html
+++ b/frontend/app/src/app/screens/race-flags/race-flags.html
@@ -1,25 +1,5 @@
-<section class="screen-page">
-	<article class="screen-panel race-flags-screen">
-		<div class="header-row">
-			<div>
-				<h1>Race Flags</h1>
-				<p class="screen-subtitle">Live track safety flag status for public display.</p>
-			</div>
-			<button class="btn btn-primary" type="button" (click)="enterFullscreen()">Full Screen</button>
-		</div>
+<section class="screen-page race-flags-page">
+	<button class="btn btn-primary fullscreen-btn" type="button" (click)="enterFullscreen()">Full Screen</button>
 
-		<div class="status-grid">
-			<p class="status-chip"><strong>Connection:</strong> {{ connected ? 'Connected' : 'Not connected' }}</p>
-			<p class="status-chip"><strong>Message:</strong> {{ message || '-' }}</p>
-		</div>
-
-		<section class="flag-panel">
-			<h2>Current Flag</h2>
-			<p *ngIf="currentFlag; else noFlag" class="flag-value" [attr.data-flag]="currentFlag">{{ currentFlag }}</p>
-
-			<ng-template #noFlag>
-				<p class="muted">No flag selected</p>
-			</ng-template>
-		</section>
-	</article>
+	<article class="flag-screen" [attr.data-flag]="currentFlag || 'red'" aria-label="Race flag display"></article>
 </section>

--- a/frontend/app/src/app/screens/race-flags/race-flags.scss
+++ b/frontend/app/src/app/screens/race-flags/race-flags.scss
@@ -1,49 +1,42 @@
-.race-flags-screen {
-	display: grid;
-	gap: 1rem;
+.race-flags-page {
+	position: relative;
+	align-content: stretch;
+	gap: 0;
 }
 
-.header-row {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 1rem;
+.fullscreen-btn {
+	position: absolute;
+	top: 0.8rem;
+	right: 0.8rem;
+	z-index: 2;
 }
 
-.flag-panel {
-	border-radius: 16px;
-	border: 1px solid rgba(182, 212, 240, 0.2);
-	background: rgba(172, 203, 236, 0.08);
-	padding: 1rem;
+.flag-screen {
+	min-height: calc(100vh - 110px);
+	border-radius: 20px;
+	border: 1px solid rgba(255, 255, 255, 0.15);
+	box-shadow: 0 20px 45px rgba(0, 0, 0, 0.32);
 }
 
-.flag-value {
-	margin: 0;
-	font-size: clamp(2rem, 6vw, 3.4rem);
-	font-weight: 800;
-	text-transform: uppercase;
-	letter-spacing: 0.04em;
+.flag-screen[data-flag='green'] {
+	background: #18b15e;
 }
 
-.flag-value[data-flag='green'] {
-	color: #89f2ae;
+.flag-screen[data-flag='yellow'] {
+	background: #f0cc2b;
 }
 
-.flag-value[data-flag='yellow'] {
-	color: #ffe27f;
+.flag-screen[data-flag='red'] {
+	background: #d84444;
 }
 
-.flag-value[data-flag='red'] {
-	color: #ff9aa8;
-}
-
-.flag-value[data-flag='finish'] {
-	color: #cde4ff;
-}
-
-@media (max-width: 720px) {
-	.header-row {
-		flex-direction: column;
-		align-items: flex-start;
-	}
+.flag-screen[data-flag='finish'] {
+	background-color: #f7f7f7;
+	background-image:
+		linear-gradient(45deg, #1b1b1b 25%, transparent 25%),
+		linear-gradient(-45deg, #1b1b1b 25%, transparent 25%),
+		linear-gradient(45deg, transparent 75%, #1b1b1b 75%),
+		linear-gradient(-45deg, transparent 75%, #1b1b1b 75%);
+	background-size: 84px 84px;
+	background-position: 0 0, 0 42px, 42px -42px, -42px 0;
 }


### PR DESCRIPTION
This PR brings the frontend race screens in line with the Task-Racetrack MVP behavior and testing checklist, with focus on race control flow, flag presentation, and operator UX consistency.

### What was changed:

- Race Control:
  - Replaced prompt-based auth with in-page access-key flow
  - Updated control visibility logic so race/flag controls are hidden in finished state
  - End Session action is presented as the primary action in finish mode
  - Added support for displaying no-upcoming-races style message from server payload

- Race Flags:
  - Reworked the screen into a dedicated visual flag display
  - Implemented full-screen style rendering for:
  - Safe: solid green
  - Hazard: solid yellow
  - Danger: solid red
  - Finish: chequered pattern
  - Kept fullscreen launch action for display usage

- Front Desk:
  - Added receptionist-driven car assignment UI (manual car selection)
  - Added client-side safeguards for invalid or duplicate car assignment attempts
  - Emitted dedicated car-assignment update event to backend contract

- Lap-line Tracker:
  - Switched from hardcoded cars to dynamic car list from realtime events
  - Improved auth-screen consistency and spacing to match Front Desk pattern

- Next Race / Leaderboard compatibility:
  - Preserved and improved fallback handling for event ordering differences
  - Kept paddock prompt behavior support in frontend flow

### Why:

- Previous UI behavior partially diverged from mandatory race-session interaction rules.
- This update closes key frontend gaps so functional behavior matches the expected MVP screen logic and operator workflow.

### Testing:

- Frontend build passed:
  - npm run build


### Notes / Constraints:

- Some acceptance criteria remain backend-dependent (event emission timing, persistence, 500ms invalid-key delay enforcement, full end-to-end race lifecycle propagation).
- Frontend now contains the required display logic and handlers for those backend events.