### PR TITLE
fix(frontend): stabilize screen auth and front-desk rendering

### DIFF
--- a/frontend/app/src/app/screens/front-desk/front-desk.html
+++ b/frontend/app/src/app/screens/front-desk/front-desk.html
@@ -62,7 +62,7 @@
 
     <div
       class="session-card"
-      *ngFor="let session of sessions"
+      *ngFor="let session of sessions; trackBy: trackBySessionId"
       [class.locked]="isLocked(session)"
     >
       <div class="session-header">
@@ -93,23 +93,27 @@
             </tr>
           </thead>
           <tbody>
-            <tr *ngFor="let driver of getDrivers(session)">
+            <tr *ngFor="let driverName of session.driverNames; let i = index; trackBy: trackByDriverName">
               <td class="car-number">
-                <span class="car-badge" *ngIf="isLocked(session)">{{ driver.carNumber }}</span>
+                <span class="car-badge" *ngIf="isLocked(session)">{{ session.carNumbers[i] }}</span>
                 <select
                   *ngIf="!isLocked(session)"
                   class="car-select"
-                  [ngModel]="driver.carNumber"
-                  (ngModelChange)="changeDriverCar(session.sessionId, driver.driverName, $event)"
-                  [attr.aria-label]="'Assign car for ' + driver.driverName"
+                  [ngModel]="session.carNumbers[i]"
+                  (ngModelChange)="changeDriverCar(session.sessionId, driverName, $event)"
+                  [attr.aria-label]="'Assign car for ' + driverName"
                 >
-                  <option *ngFor="let car of getAvailableCars(session, driver.carNumber)" [ngValue]="car">
+                  <option
+                    *ngFor="let car of carOptions"
+                    [ngValue]="car"
+                    [disabled]="session.carNumbers.includes(car) && car !== session.carNumbers[i]"
+                  >
                     {{ car }}
                   </option>
                 </select>
               </td>
 
-              <td *ngIf="isEditing(session.sessionId, driver.driverName)">
+              <td *ngIf="isEditing(session.sessionId, driverName)">
                 <input
                   class="inline-input"
                   type="text"
@@ -119,25 +123,25 @@
                 />
               </td>
 
-              <td *ngIf="!isEditing(session.sessionId, driver.driverName)">
-                {{ driver.driverName }}
+              <td *ngIf="!isEditing(session.sessionId, driverName)">
+                {{ driverName }}
               </td>
 
               <td *ngIf="!isLocked(session)" class="driver-actions">
-                <ng-container *ngIf="isEditing(session.sessionId, driver.driverName)">
+                <ng-container *ngIf="isEditing(session.sessionId, driverName)">
                   <button class="btn btn-success btn-xs" (click)="confirmEdit()" title="Confirm">✓</button>
                   <button class="btn btn-ghost btn-xs" (click)="cancelEdit()" title="Cancel">✕</button>
                 </ng-container>
 
-                <ng-container *ngIf="!isEditing(session.sessionId, driver.driverName)">
+                <ng-container *ngIf="!isEditing(session.sessionId, driverName)">
                   <button
                     class="btn btn-ghost btn-xs"
-                    (click)="startEdit(session.sessionId, driver.driverName)"
+                    (click)="startEdit(session.sessionId, driverName)"
                     title="Edit name"
-                  >✏</button>
+                  >Edit</button>
                   <button
                     class="btn btn-danger btn-xs"
-                    (click)="removeDriver(session.sessionId, driver.driverName)"
+                    (click)="removeDriver(session.sessionId, driverName)"
                     title="Remove driver"
                   >Delete</button>
                 </ng-container>

--- a/frontend/app/src/app/screens/front-desk/front-desk.ts
+++ b/frontend/app/src/app/screens/front-desk/front-desk.ts
@@ -39,6 +39,7 @@ export class FrontDeskComponent implements OnInit, OnDestroy {
   newDriverNames: Record<number, string> = {};
   editingDriver: { sessionId: number; driverName: string } | null = null;
   editingNewName: string = '';
+  readonly carOptions: number[] = [1, 2, 3, 4, 5, 6, 7, 8];
 
   ngOnInit(): void {
     this.initSocket();
@@ -286,6 +287,14 @@ export class FrontDeskComponent implements OnInit, OnDestroy {
 
   canAddDriver(session: Session): boolean {
     return session.driverNames.length < 8 && !this.isLocked(session);
+  }
+
+  trackBySessionId(_index: number, session: Session): number {
+    return session.sessionId;
+  }
+
+  trackByDriverName(_index: number, driverName: string): string {
+    return driverName;
   }
 
   getAvailableCars(session: Session, currentCar: number): number[] {

--- a/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.ts
+++ b/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, ChangeDetectorRef, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { io, Socket } from 'socket.io-client';
@@ -20,6 +20,9 @@ type SessionUpdatePayload = {
 })
 export class LapLineTracker implements OnInit, OnDestroy {
   private socket!: Socket;
+  private pendingLogin = false;
+  private loginTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private cdr = inject(ChangeDetectorRef);
 
   carNumbers: number[] = [];
 
@@ -34,11 +37,20 @@ export class LapLineTracker implements OnInit, OnDestroy {
   private hasRaceProgressed = false;
 
   ngOnInit(): void {
-    this.socket = io({ autoConnect: false, reconnection: true });
+    this.socket = io({
+      autoConnect: false,
+      reconnection: true,
+      reconnectionAttempts: 5,
+      reconnectionDelay: 1000,
+      timeout: 5000
+    });
 
     this.socket.on('connect', () => {
-      this.isConnected = true;
-      this.joinLapLineRoom();
+      if (this.pendingLogin || this.isAuthenticated) {
+        this.pendingLogin = false;
+        this.isConnected = true;
+        this.joinLapLineRoom();
+      }
     });
 
     this.socket.on('disconnect', () => {
@@ -46,12 +58,22 @@ export class LapLineTracker implements OnInit, OnDestroy {
       if (this.isAuthenticated) {
         this.statusMessage = 'Connection lost. Reconnecting...';
       }
+      this.cdr.detectChanges();
     });
 
     this.socket.on('connect_error', () => {
-      this.isConnecting = false;
-      this.isConnected = false;
-      this.statusMessage = 'Unable to connect to server.';
+      this.clearLoginTimeout();
+      if (this.isAuthenticated) {
+        this.authError = '';
+      } else {
+        this.pendingLogin = false;
+        this.isConnecting = false;
+        this.isConnected = false;
+        this.isAuthenticated = false;
+        this.authError = 'Unable to connect to server.';
+        this.statusMessage = 'Authentication required.';
+      }
+      this.cdr.detectChanges();
     });
 
     this.socket.on('sessionStatus', (args: { status: SessionStatus }) => {
@@ -78,18 +100,22 @@ export class LapLineTracker implements OnInit, OnDestroy {
       }
 
       this.statusMessage = 'Waiting for race start.';
+      this.cdr.detectChanges();
     });
 
     this.socket.on('sessionUpdate', (args: SessionUpdatePayload) => {
       this.applyCarNumbers(args.carNumbers);
+      this.cdr.detectChanges();
     });
 
     this.socket.on('lapTimes', (args: { carNumbers: number[] }) => {
       this.applyCarNumbers(args.carNumbers);
+      this.cdr.detectChanges();
     });
   }
 
   ngOnDestroy(): void {
+    this.clearLoginTimeout();
     if (this.socket) {
       this.socket.disconnect();
     }
@@ -103,12 +129,14 @@ export class LapLineTracker implements OnInit, OnDestroy {
     this.isConnecting = true;
     this.authError = '';
     this.statusMessage = 'Connecting...';
+    this.startLoginTimeout();
 
     if (this.socket.connected) {
       this.joinLapLineRoom();
       return;
     }
 
+    this.pendingLogin = true;
     this.socket.connect();
   }
 
@@ -129,16 +157,28 @@ export class LapLineTracker implements OnInit, OnDestroy {
   }
 
   private joinLapLineRoom(): void {
-    this.socket.emit(
+    this.socket.timeout(5000).emit(
       'selectRoom',
       { room: 'lap-line-tracker', key: this.accessKey },
-      (response: { status: string }) => {
+      (err: Error | null, response: { status: string }) => {
+        this.clearLoginTimeout();
+        if (err) {
+          this.isConnecting = false;
+          this.isConnected = false;
+          this.isAuthenticated = false;
+          this.authError = 'Server did not respond in time. Please try again.';
+          this.statusMessage = 'Authentication required.';
+          this.cdr.detectChanges();
+          return;
+        }
+
         this.isConnecting = false;
 
         if (response?.status === 'Success') {
           this.isAuthenticated = true;
           this.authError = '';
           this.statusMessage = 'Connected. Waiting for race start.';
+          this.cdr.detectChanges();
           return;
         }
 
@@ -148,8 +188,33 @@ export class LapLineTracker implements OnInit, OnDestroy {
           : (response?.status ?? 'Room connection failed.');
         this.statusMessage = 'Authentication required.';
         this.socket.disconnect();
+        this.cdr.detectChanges();
       }
     );
+  }
+
+  private startLoginTimeout(): void {
+    this.clearLoginTimeout();
+    this.loginTimeoutId = setTimeout(() => {
+      if (!this.isConnecting) {
+        return;
+      }
+      this.pendingLogin = false;
+      this.isAuthenticated = false;
+      this.isConnected = false;
+      this.isConnecting = false;
+      this.authError = 'Connection timed out. Please try again.';
+      this.statusMessage = 'Authentication required.';
+      this.socket.disconnect();
+      this.cdr.detectChanges();
+    }, 8000);
+  }
+
+  private clearLoginTimeout(): void {
+    if (this.loginTimeoutId !== null) {
+      clearTimeout(this.loginTimeoutId);
+      this.loginTimeoutId = null;
+    }
   }
 
   private applyCarNumbers(carNumbers: number[]): void {

--- a/frontend/app/src/app/screens/race-control/race-control.ts
+++ b/frontend/app/src/app/screens/race-control/race-control.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, ChangeDetectorRef, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { io, Socket } from 'socket.io-client';
@@ -22,6 +22,9 @@ type NextSessionPayload = {
 })
 export class RaceControl implements OnInit, OnDestroy {
   private socket!: Socket;
+  private pendingLogin = false;
+  private loginTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private cdr = inject(ChangeDetectorRef);
 
   connected = false;
   sessionStatus: SessionStatus = 'notStarted';
@@ -34,10 +37,19 @@ export class RaceControl implements OnInit, OnDestroy {
   accessKey = '';
 
   ngOnInit(): void {
-    this.socket = io({ autoConnect: false, reconnection: true });
+    this.socket = io({
+      autoConnect: false,
+      reconnection: true,
+      reconnectionAttempts: 5,
+      reconnectionDelay: 1000,
+      timeout: 5000
+    });
 
     this.socket.on('connect', () => {
-      this.joinRaceControlRoom();
+      if (this.pendingLogin || this.connected) {
+        this.pendingLogin = false;
+        this.joinRaceControlRoom();
+      }
     });
 
     this.socket.on('disconnect', () => {
@@ -45,31 +57,43 @@ export class RaceControl implements OnInit, OnDestroy {
       if (this.accessKey.trim()) {
         this.message = 'Connection lost';
       }
+      this.cdr.detectChanges();
     });
 
     this.socket.on('connect_error', () => {
-      this.connected = false;
-      this.isConnecting = false;
-      this.authError = 'Unable to connect to server.';
-      this.message = 'Authentication required.';
+      this.clearLoginTimeout();
+      if (this.connected) {
+        this.authError = '';
+      } else {
+        this.connected = false;
+        this.pendingLogin = false;
+        this.isConnecting = false;
+        this.authError = 'Unable to connect to server.';
+        this.message = 'Authentication required.';
+      }
+      this.cdr.detectChanges();
     });
 
     this.socket.on('sessionStatus', (args: { status: SessionStatus }) => {
       this.sessionStatus = args.status;
+      this.cdr.detectChanges();
     });
 
     this.socket.on('flagChanged', (args: { flag: RaceFlag }) => {
       this.currentFlag = args.flag;
+      this.cdr.detectChanges();
     });
 
     this.socket.on('nextSessionUpdate', (data: unknown) => {
       if (this.isNextSessionPayload(data)) {
         this.nextSessionMessage = '';
+        this.cdr.detectChanges();
         return;
       }
 
       if (data && typeof data === 'object' && 'message' in data) {
         this.nextSessionMessage = String((data as { message?: string }).message ?? 'No upcoming races');
+        this.cdr.detectChanges();
       }
     });
   }
@@ -82,12 +106,14 @@ export class RaceControl implements OnInit, OnDestroy {
     this.isConnecting = true;
     this.authError = '';
     this.message = 'Connecting...';
+    this.startLoginTimeout();
 
     if (this.socket.connected) {
       this.joinRaceControlRoom();
       return;
     }
 
+    this.pendingLogin = true;
     this.socket.connect();
   }
 
@@ -151,16 +177,27 @@ export class RaceControl implements OnInit, OnDestroy {
   }
 
   private joinRaceControlRoom(): void {
-    this.socket.emit(
+    this.socket.timeout(5000).emit(
       'selectRoom',
       { room: 'race-control', key: this.accessKey },
-      (response: { status: string }) => {
+      (err: Error | null, response: { status: string }) => {
+        this.clearLoginTimeout();
+        if (err) {
+          this.isConnecting = false;
+          this.connected = false;
+          this.authError = 'Server did not respond in time. Please try again.';
+          this.message = 'Authentication required.';
+          this.cdr.detectChanges();
+          return;
+        }
+
         this.isConnecting = false;
 
         if (response?.status === 'Success') {
           this.connected = true;
           this.authError = '';
           this.message = 'Connected';
+          this.cdr.detectChanges();
           return;
         }
 
@@ -170,11 +207,36 @@ export class RaceControl implements OnInit, OnDestroy {
           : (response?.status ?? 'Authentication failed.');
         this.message = 'Authentication required.';
         this.socket.disconnect();
+        this.cdr.detectChanges();
       }
     );
   }
 
+  private startLoginTimeout(): void {
+    this.clearLoginTimeout();
+    this.loginTimeoutId = setTimeout(() => {
+      if (!this.isConnecting) {
+        return;
+      }
+      this.pendingLogin = false;
+      this.connected = false;
+      this.isConnecting = false;
+      this.authError = 'Connection timed out. Please try again.';
+      this.message = 'Authentication required.';
+      this.socket.disconnect();
+      this.cdr.detectChanges();
+    }, 8000);
+  }
+
+  private clearLoginTimeout(): void {
+    if (this.loginTimeoutId !== null) {
+      clearTimeout(this.loginTimeoutId);
+      this.loginTimeoutId = null;
+    }
+  }
+
   ngOnDestroy(): void {
+    this.clearLoginTimeout();
     if (this.socket) {
       this.socket.disconnect();
     }


### PR DESCRIPTION
This PR fixes frontend stability issues across operational screens:

- Prevents race-control and lap-line-tracker login from hanging in Connecting state
- Aligns race-control and lap-line-tracker auth flow with the robust front-desk connection pattern
- Stabilizes front-desk driver table rendering to prevent UI freeze when adding drivers

### What changed

- Race Control:
  - Added pending-login flow and guarded room join
  - Added connection timeout handling
  - Added selectRoom ack timeout handling
  - Improved state cleanup on connect/disconnect/errors
- Lap-line Tracker:
  - Added pending-login flow and guarded room join
  - Added connection timeout handling
  - Added selectRoom ack timeout handling
  - Improved state cleanup on connect/disconnect/errors
- Front Desk:
  - Removed expensive template method churn in driver rows
  - Added stable trackBy usage for sessions/drivers
  - Switched to stable car options rendering logic


These changes make socket auth behavior deterministic and UI rendering stable

Manual flow tested:

- Front Desk login, create session, add driver
- Race Control login with valid key
- Lap-line Tracker login with valid key
