### PR TITLE
fix(backend): stabilize race lifecycle, first start flow, and lap counting

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -204,14 +204,14 @@ io.on("connection", (socket) => {
                 .to("leader-board")
                 .emit("sessionStatus", { status: repository.currentRace.status });
 
-                io.to("leader-board").emit("sessionUpdate", {
+                io.to("leader-board").to("lap-line-tracker").emit("sessionUpdate", {
                     sessionId: repository.currentRace.sessionId,
                     driverNames: repository.currentRace.driverNames,
                     carNumbers: repository.currentRace.carNumbers
                 });
                 timer = setInterval(() => {
-                    stopRaceTimer();
                     if (repository.currentRace.remainingSeconds < 0) {
+                        stopRaceTimer();
                         repository.endRace();
                         repository.currentRace.flag = "finish";
                         repository.currentRace.remainingSeconds = 0;
@@ -223,9 +223,6 @@ io.on("connection", (socket) => {
 
                         broadcastFlagChanged();
                         io.to("leader-board").emit("timerTick", { remainingSeconds: repository.currentRace.remainingSeconds });
-
-                        clearInterval(timer);
-                        timer = undefined;
                     }
                     else {
                         io.to("leader-board").emit("timerTick", { remainingSeconds: repository.currentRace.remainingSeconds });

--- a/backend/index.js
+++ b/backend/index.js
@@ -136,12 +136,17 @@ io.on("connection", (socket) => {
         }
         callback({ status: status });
         if (args.flag === "finish") {
+            if (timer !== undefined) {
+                clearInterval(timer);
+                timer = undefined;
+            }            
             repository.endRace();
             io.to("race-control")
             .to("lap-line-tracker")
             .to("leader-board")
             .emit("sessionStatus", { status: repository.currentRace.status });
             repository.currentRace.remainingSeconds = 0;
+            io.to("leader-board").emit("timerTick", { remainingSeconds: repository.currentRace.remainingSeconds });
         }
     });
     socket.on("raceStartCountdown", (args, callback) => {
@@ -154,11 +159,9 @@ io.on("connection", (socket) => {
         let result = repository.beginStartCountdown();
 
         if (result === "No session loaded") {
-            if (result === "No session loaded") {
-                if (repository.sessions.length === 0) {
-                    callback({ status: "No session loaded" });
-                    return;
-                }
+            if (repository.sessions.length === 0) {
+                callback({ status: "No session loaded" });
+                return;
             }
             repository.loadSession(repository.sessions[0].sessionId);
             broadcastFlagChanged();
@@ -206,13 +209,16 @@ io.on("connection", (socket) => {
                 timer = setInterval(() => {
                     if (repository.currentRace.remainingSeconds < 0) {
                         repository.endRace();
+                        repository.currentRace.remainingSeconds = 0;
                         io.to("race-control")
                         .to("lap-line-tracker")
                         .to("leader-board")
                         .emit("sessionStatus", { status: repository.currentRace.status });
                         repository.currentRace.flag = "finish";
                         broadcastFlagChanged();
+                        io.to("leader-board").emit("timerTick", { remainingSeconds: repository.currentRace.remainingSeconds });
                         clearInterval(timer);
+                        timer = undefined;
                     }
                     else {
                         io.to("leader-board").emit("timerTick", { remainingSeconds: repository.currentRace.remainingSeconds });
@@ -229,8 +235,7 @@ io.on("connection", (socket) => {
         }
 
         if (repository.sessions.length < 2) {
-            // no next session → broadcast empty state
-            io.to("next-race").emit("nextSessionUpdate", { message: "No upcoming races" });
+            broadcastNextSession();
             return;
         }
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -56,6 +56,13 @@ const repository = new Repository(raceDuration, 10);
 
 let timer = undefined;
 
+function stopRaceTimer() {
+    if (timer !== undefined) {
+        clearInterval(timer);
+        timer = undefined;
+    }
+}
+
 if (!("NGROK_AUTHTOKEN" in env)) {
     console.error("NGROK_AUTHTOKEN environment variable not set. Please set it to your ngrok authtoken or to \"none\" to run locally.");
     console.error("Sign up for an account: https://dashboard.ngrok.com/signup");
@@ -132,12 +139,14 @@ io.on("connection", (socket) => {
         }
         callback({ status: status });
         if (args.flag === "finish") {
+            stopRaceTimer();
             repository.endRace();
+            repository.currentRace.remainingSeconds = 0;
             io.to("race-control")
             .to("lap-line-tracker")
             .to("leader-board")
             .emit("sessionStatus", { status: repository.currentRace.status });
-            repository.currentRace.remainingSeconds = 0;
+            io.to("leader-board").emit("timerTick", { remainingSeconds: repository.currentRace.remainingSeconds });
         }
     });
     socket.on("raceStartCountdown", (args, callback) => {
@@ -150,13 +159,13 @@ io.on("connection", (socket) => {
         let result = repository.beginStartCountdown();
 
         if (result === "No session loaded") {
-            if (result === "No session loaded") {
-                if (repository.sessions.length === 0) {
-                    callback({ status: "No session loaded" });
-                    return;
-                }
+            const firstUpcomingSession = repository.sessions[0];
+            if (!firstUpcomingSession) {
+                callback({ status: "No session loaded" });
+                return;
             }
-            repository.loadSession(repository.sessions[0].sessionId);
+
+            repository.loadSession(firstUpcomingSession.sessionId);
             broadcastFlagChanged();
             broadcastSessionStatus();
             broadcastNextSession();
@@ -176,6 +185,7 @@ io.on("connection", (socket) => {
         }, (err, response) => {
             if (err) {
                 repository.countdownInProgress = false;
+                stopRaceTimer();
                 callback({ status: "Invalid Session Status" });
                 console.log("No clients responded to startCountdown event, aborting countdown");
                 return;
@@ -194,21 +204,28 @@ io.on("connection", (socket) => {
                 .to("leader-board")
                 .emit("sessionStatus", { status: repository.currentRace.status });
 
-                io.to("leader-board").to("lap-line-tracker").emit("sessionUpdate", {
+                io.to("leader-board").emit("sessionUpdate", {
                     sessionId: repository.currentRace.sessionId,
                     driverNames: repository.currentRace.driverNames,
                     carNumbers: repository.currentRace.carNumbers
                 });
                 timer = setInterval(() => {
+                    stopRaceTimer();
                     if (repository.currentRace.remainingSeconds < 0) {
                         repository.endRace();
+                        repository.currentRace.flag = "finish";
+                        repository.currentRace.remainingSeconds = 0;
+
                         io.to("race-control")
                         .to("lap-line-tracker")
                         .to("leader-board")
                         .emit("sessionStatus", { status: repository.currentRace.status });
-                        repository.currentRace.flag = "finish";
+
                         broadcastFlagChanged();
+                        io.to("leader-board").emit("timerTick", { remainingSeconds: repository.currentRace.remainingSeconds });
+
                         clearInterval(timer);
+                        timer = undefined;
                     }
                     else {
                         io.to("leader-board").emit("timerTick", { remainingSeconds: repository.currentRace.remainingSeconds });
@@ -225,6 +242,9 @@ io.on("connection", (socket) => {
         if (!socket.rooms.has("race-control")) {
             return;
         }
+
+        stopRaceTimer();
+
         if (repository.sessions.length < 2) {
             repository.addSession([], []);
         }

--- a/backend/index.js
+++ b/backend/index.js
@@ -56,13 +56,6 @@ const repository = new Repository(raceDuration, 10);
 
 let timer = undefined;
 
-function stopRaceTimer() {
-    if (timer !== undefined) {
-        clearInterval(timer);
-        timer = undefined;
-    }
-}
-
 if (!("NGROK_AUTHTOKEN" in env)) {
     console.error("NGROK_AUTHTOKEN environment variable not set. Please set it to your ngrok authtoken or to \"none\" to run locally.");
     console.error("Sign up for an account: https://dashboard.ngrok.com/signup");
@@ -97,6 +90,10 @@ function broadcastNextSession() {
     const session = repository.sessions.length >= 2 ? repository.getSession(repository.sessions[1].sessionId) : null;
     if (session !== null) {
         io.to("next-race").emit("nextSessionUpdate", session);
+        io.to("race-control").emit("nextSessionUpdate", session);
+    } else {
+        io.to("next-race").emit("nextSessionUpdate", { message: "No upcoming races. Proceed to paddock." });
+        io.to("race-control").emit("nextSessionUpdate", { message: "No upcoming races" });
     }
 }
 
@@ -139,14 +136,12 @@ io.on("connection", (socket) => {
         }
         callback({ status: status });
         if (args.flag === "finish") {
-            stopRaceTimer();
             repository.endRace();
-            repository.currentRace.remainingSeconds = 0;
             io.to("race-control")
             .to("lap-line-tracker")
             .to("leader-board")
             .emit("sessionStatus", { status: repository.currentRace.status });
-            io.to("leader-board").emit("timerTick", { remainingSeconds: repository.currentRace.remainingSeconds });
+            repository.currentRace.remainingSeconds = 0;
         }
     });
     socket.on("raceStartCountdown", (args, callback) => {
@@ -159,13 +154,13 @@ io.on("connection", (socket) => {
         let result = repository.beginStartCountdown();
 
         if (result === "No session loaded") {
-            const firstUpcomingSession = repository.sessions[0];
-            if (!firstUpcomingSession) {
-                callback({ status: "No session loaded" });
-                return;
+            if (result === "No session loaded") {
+                if (repository.sessions.length === 0) {
+                    callback({ status: "No session loaded" });
+                    return;
+                }
             }
-
-            repository.loadSession(firstUpcomingSession.sessionId);
+            repository.loadSession(repository.sessions[0].sessionId);
             broadcastFlagChanged();
             broadcastSessionStatus();
             broadcastNextSession();
@@ -185,7 +180,6 @@ io.on("connection", (socket) => {
         }, (err, response) => {
             if (err) {
                 repository.countdownInProgress = false;
-                stopRaceTimer();
                 callback({ status: "Invalid Session Status" });
                 console.log("No clients responded to startCountdown event, aborting countdown");
                 return;
@@ -211,27 +205,21 @@ io.on("connection", (socket) => {
                 });
                 timer = setInterval(() => {
                     if (repository.currentRace.remainingSeconds < 0) {
-                        stopRaceTimer();
                         repository.endRace();
-                        repository.currentRace.flag = "finish";
-                        repository.currentRace.remainingSeconds = 0;
-
                         io.to("race-control")
                         .to("lap-line-tracker")
                         .to("leader-board")
                         .emit("sessionStatus", { status: repository.currentRace.status });
-
+                        repository.currentRace.flag = "finish";
                         broadcastFlagChanged();
-                        io.to("leader-board").emit("timerTick", { remainingSeconds: repository.currentRace.remainingSeconds });
+                        clearInterval(timer);
                     }
                     else {
                         io.to("leader-board").emit("timerTick", { remainingSeconds: repository.currentRace.remainingSeconds });
                         repository.currentRace.remainingSeconds--;
                     }
                 }, 1000);
-                if (repository.sessions.length >= 2) {
-                    io.to("next-race").emit("nextSessionUpdate", repository.getSession(repository.sessions[1].sessionId));
-                }
+                broadcastNextSession();
             }, repository.defaultCountdownDuration * 1000)
         });
     });
@@ -240,12 +228,24 @@ io.on("connection", (socket) => {
             return;
         }
 
-        stopRaceTimer();
-
         if (repository.sessions.length < 2) {
-            repository.addSession([], []);
+            // no next session → broadcast empty state
+            io.to("next-race").emit("nextSessionUpdate", { message: "No upcoming races" });
+            return;
         }
+
         repository.loadSession(repository.sessions[1].sessionId);
+
+        broadcastFlagChanged();
+        broadcastSessionStatus();
+        broadcastNextSession();
+
+        io.to("leader-board").to("lap-line-tracker").emit("sessionUpdate", {
+            sessionId: repository.currentRace.sessionId,
+            driverNames: repository.currentRace.driverNames,
+            carNumbers: repository.currentRace.carNumbers
+        });
+
         io.to("race-control")
         .to("leader-board")
         .to("race-flags")
@@ -259,6 +259,7 @@ io.on("connection", (socket) => {
         io.to("front-desk").emit("sessionsUpdated", repository.sessions);
 
         io.to("front-desk").emit("sessionStarted", { sessionId: repository.currentRace.sessionId });
+        broadcastNextSession();
     });
 
     socket.on("sessionCreated", (args) => {

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -290,21 +290,24 @@ class Repository {
 
     addLap(carNumber) {
         for (let i = 0; i < this.currentRace.carNumbers.length; i++) {
-            if (this.currentRace.completedLaps[i] === 0) {
-                this.currentRace.completedLaps[i] = 1;
-                this.currentRace.lastLapStartTimes[i] = Date.now();
-                return;
-            }
+            if (this.currentRace.carNumbers[i] === carNumber) {
+                if (this.currentRace.completedLaps[i] === 0) {
+                    this.currentRace.completedLaps[i] = 1;
+                    this.currentRace.lastLapStartTimes[i] = Date.now();
+                    return;
+                }
 
-            this.currentRace.completedLaps[i]++;
-            const lapTimeStamp = Date.now();
-            const lapTime = (lapTimeStamp - this.currentRace.lastLapStartTimes[i]) / 1000;
-            this.currentRace.lastLapStartTimes[i] = lapTimeStamp;
-            if (this.currentRace.bestLapTime[i] === 0) {
-                this.currentRace.bestLapTime[i] = lapTime;
-            }
-            else if (this.currentRace.bestLapTime[i] > lapTime) {
-                this.currentRace.bestLapTime[i] = lapTime;
+                this.currentRace.completedLaps[i]++;
+                const lapTimeStamp = Date.now();
+                const lapTime = (lapTimeStamp - this.currentRace.lastLapStartTimes[i]) / 1000;
+                this.currentRace.lastLapStartTimes[i] = lapTimeStamp;
+                if (this.currentRace.bestLapTime[i] === 0) {
+                    this.currentRace.bestLapTime[i] = lapTime;
+                }
+                else if (this.currentRace.bestLapTime[i] > lapTime) {
+                    this.currentRace.bestLapTime[i] = lapTime;
+                }
+                return;
             }
         } 
     }

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -291,7 +291,8 @@ class Repository {
     addLap(carNumber) {
         for (let i = 0; i < this.currentRace.carNumbers.length; i++) {
             if (this.currentRace.carNumbers[i] === carNumber) {
-                if (this.currentRace.lastLapStartTimes[i] === 0) {
+                if (this.currentRace.completedLaps[i] === 0) {
+                    this.currentRace.completedLaps[i] = 1;
                     this.currentRace.lastLapStartTimes[i] = Date.now();
                     return;
                 }

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -291,15 +291,13 @@ class Repository {
     addLap(carNumber) {
         for (let i = 0; i < this.currentRace.carNumbers.length; i++) {
             if (this.currentRace.carNumbers[i] === carNumber) {
-                if (this.currentRace.completedLaps[i] === 0) {
-                    this.currentRace.completedLaps[i] = 1;
+                if (this.currentRace.lastLapStartTimes[i] === 0) {
                     this.currentRace.lastLapStartTimes[i] = Date.now();
                     return;
                 }
-
                 this.currentRace.completedLaps[i]++;
                 const lapTimeStamp = Date.now();
-                const lapTime = (lapTimeStamp - this.currentRace.lastLapStartTimes[i]) / 1000;
+                const lapTime = (lapTimeStamp - this.currentRace.lastLapStartTimes[i]);
                 this.currentRace.lastLapStartTimes[i] = lapTimeStamp;
                 if (this.currentRace.bestLapTime[i] === 0) {
                     this.currentRace.bestLapTime[i] = lapTime;
@@ -307,7 +305,6 @@ class Repository {
                 else if (this.currentRace.bestLapTime[i] > lapTime) {
                     this.currentRace.bestLapTime[i] = lapTime;
                 }
-                return;
             }
         } 
     }

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -290,21 +290,21 @@ class Repository {
 
     addLap(carNumber) {
         for (let i = 0; i < this.currentRace.carNumbers.length; i++) {
-            if (this.currentRace.carNumbers[i] === carNumber) {
-                if (this.currentRace.lastLapStartTimes[i] === 0) {
-                    this.currentRace.lastLapStartTimes[i] = Date.now();
-                    return;
-                }
-                this.currentRace.completedLaps[i]++;
-                const lapTimeStamp = Date.now();
-                const lapTime = (lapTimeStamp - this.currentRace.lastLapStartTimes[i]) / 1000;
-                this.currentRace.lastLapStartTimes[i] = lapTimeStamp;
-                if (this.currentRace.bestLapTime[i] === 0) {
-                    this.currentRace.bestLapTime[i] = lapTime;
-                }
-                else if (this.currentRace.bestLapTime[i] > lapTime) {
-                    this.currentRace.bestLapTime[i] = lapTime;
-                }
+            if (this.currentRace.completedLaps[i] === 0) {
+                this.currentRace.completedLaps[i] = 1;
+                this.currentRace.lastLapStartTimes[i] = Date.now();
+                return;
+            }
+
+            this.currentRace.completedLaps[i]++;
+            const lapTimeStamp = Date.now();
+            const lapTime = (lapTimeStamp - this.currentRace.lastLapStartTimes[i]) / 1000;
+            this.currentRace.lastLapStartTimes[i] = lapTimeStamp;
+            if (this.currentRace.bestLapTime[i] === 0) {
+                this.currentRace.bestLapTime[i] = lapTime;
+            }
+            else if (this.currentRace.bestLapTime[i] > lapTime) {
+                this.currentRace.bestLapTime[i] = lapTime;
             }
         } 
     }


### PR DESCRIPTION
Closes #62
Closes #63
Closes #64

This PR fixes the core race lifecycle by:
- loading the first upcoming session when no active session is loaded
- correcting lap counting and fastest lap timing flow
- stopping the timer correctly on finish and session end
- sending finish flag updates when the timer expires
- restricting sessionUpdate to the correct room