### PR TITLE
fix: session end flow and next race fallback states

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -90,6 +90,10 @@ function broadcastNextSession() {
     const session = repository.sessions.length >= 2 ? repository.getSession(repository.sessions[1].sessionId) : null;
     if (session !== null) {
         io.to("next-race").emit("nextSessionUpdate", session);
+        io.to("race-control").emit("nextSessionUpdate", session);
+    } else {
+        io.to("next-race").emit("nextSessionUpdate", { message: "No upcoming races. Proceed to paddock." });
+        io.to("race-control").emit("nextSessionUpdate", { message: "No upcoming races" });
     }
 }
 
@@ -212,9 +216,7 @@ io.on("connection", (socket) => {
                         repository.currentRace.remainingSeconds--;
                     }
                 }, 1000);
-                if (repository.sessions.length >= 2) {
-                    io.to("next-race").emit("nextSessionUpdate", repository.getSession(repository.sessions[1].sessionId));
-                }
+                broadcastNextSession();
             }, repository.defaultCountdownDuration * 1000)
         });
     });
@@ -239,6 +241,7 @@ io.on("connection", (socket) => {
         io.to("front-desk").emit("sessionsUpdated", repository.sessions);
 
         io.to("front-desk").emit("sessionStarted", { sessionId: repository.currentRace.sessionId });
+        broadcastNextSession();
     });
 
     socket.on("sessionCreated", (args) => {

--- a/frontend/app/src/app/screens/next-race/next-race.html
+++ b/frontend/app/src/app/screens/next-race/next-race.html
@@ -38,7 +38,12 @@
     </ng-container>
 
     <ng-template #noSession>
-      <p class="muted">No upcoming session available.</p>
+      <div>
+        <p class="muted">{{ message || 'No upcoming races.' }}</p>
+        <p *ngIf="showPaddockPrompt" class="ended-message">
+          Please proceed to the paddock.
+        </p>
+      </div>
     </ng-template>
   </article>
 </section>

--- a/frontend/app/src/app/screens/next-race/next-race.ts
+++ b/frontend/app/src/app/screens/next-race/next-race.ts
@@ -75,6 +75,7 @@ export class NextRace implements OnInit, OnDestroy {
       if (this.isNextSessionPayload(data)) {
         this.nextSession = data;
         this.message = '';
+        this.showPaddockPrompt = false;
 
         if (data.status === 'ended') {
           this.showPaddockPrompt = true;
@@ -86,7 +87,10 @@ export class NextRace implements OnInit, OnDestroy {
 
       if (data && typeof data === 'object' && 'message' in data) {
         this.nextSession = null;
-        this.message = String((data as { message?: string }).message ?? 'No upcoming session available');
+        this.message = String((data as { message?: string }).message ?? 'No upcoming races');
+        if (this.hasRaceProgressed) {
+          this.showPaddockPrompt = true;
+        }
         this.cdr.detectChanges();
         return;
       }

--- a/frontend/app/src/app/screens/race-control/race-control.html
+++ b/frontend/app/src/app/screens/race-control/race-control.html
@@ -69,6 +69,9 @@
 			</button>
 		</section>
 
-		<p class="muted" *ngIf="nextSessionMessage">{{ nextSessionMessage }}</p>
+		<section class="control-group" *ngIf="nextSessionMessage">
+			<h2>Next Session</h2>
+			<p class="session-status">{{ nextSessionMessage }}</p>
+		</section>
 	</article>
 </section>


### PR DESCRIPTION
I've successfully implemented fixes for all three interconnected issues. Here's what was changed:

## Backend Changes (index.js)
1. Enhanced broadcastNextSession() function
   - Now always broadcasts to both "next-race" and "race-control" rooms
   - Sends actual session data when a next session exists
   - Sends fallback messages when no sessions are available

2. Updated sessionEnd handler
    - Added call to broadcastNextSession() to ensure screens get updated after session ends

3. Streamlined race countdown
   - Uses the new broadcastNextSession() function for consistency

## Frontend Changes

### Next Race Component (next-race.ts & next-race.html)
  - Enhanced fallback message handling to properly show server messages
  - Shows paddock instruction when race has progressed but no next session exists
  - Template now displays the fallback message from server alongside paddock prompt

### Race Control Component (race-control.html)
   - Added dedicated "Next Session" section to prominently display session status
   - Shows "No upcoming races" message when applicable
   - Ensures visibility of system state after session ends

### How It Addresses Each Issue

| Issue | Solution |
| --- | --- |
| Closes #57 : Paddock instruction | Backend now broadcasts, Next Race template shows it alongside next session info or fallback |
| Closes #58 : Race Control no-races state | New dedicated section shows clear "No upcoming races" message when applicable |
| Closes #61 : Next Race fallback states | Proper state handling for all scenarios: next session exists, no session, race in progress |