### PR TITLE
Fix race session state regressions

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -56,6 +56,10 @@ const repository = new Repository(raceDuration, 10);
 
 let timer = undefined;
 
+function getEditableSessions() {
+    return repository.sessions.filter((session) => session.sessionId !== repository.currentRace.sessionId);
+}
+
 const timerTick = function() {
     if (repository.currentRace.remainingSeconds < 0) {
         repository.endRace();
@@ -81,7 +85,7 @@ if (env.NGROK_AUTHTOKEN !== "none") {
     	.then(listener => console.log(`Ingress established at: ${listener.url()}`));
 }
 function sessionsUpdated() {
-    io.to("front-desk").emit("sessionsUpdated", repository.sessions);
+    io.to("front-desk").emit("sessionsUpdated", getEditableSessions());
 }
 
 function broadcastSessionStatus() {
@@ -192,7 +196,7 @@ io.on("connection", (socket) => {
             broadcastFlagChanged();
             broadcastSessionStatus();
             broadcastNextSession();
-            io.to("front-desk").emit("sessionsUpdated", repository.sessions);
+            sessionsUpdated();
             io.to("front-desk").emit("sessionStarted", { sessionId: repository.currentRace.sessionId });
             result = repository.beginStartCountdown();
         }
@@ -272,7 +276,7 @@ io.on("connection", (socket) => {
         .to("leader-board")
         .emit("sessionStatus", { status: repository.currentRace.status });
 
-        io.to("front-desk").emit("sessionsUpdated", repository.sessions);
+        sessionsUpdated();
 
         io.to("front-desk").emit("sessionStarted", { sessionId: repository.currentRace.sessionId });
     });

--- a/backend/on_connection.js
+++ b/backend/on_connection.js
@@ -43,7 +43,10 @@ module.exports = function onConnection (socket, repository, room) {
             socket.emit("flagChanged", { flag: repository.currentRace.flag });
             break;
         case "front-desk":
-            socket.emit("sessionsUpdated", repository.sessions);
+            socket.emit(
+                "sessionsUpdated",
+                repository.sessions.filter((session) => session.sessionId !== repository.currentRace.sessionId)
+            );
             if (repository.currentRace.sessionId !== null) {
                 socket.emit("sessionStarted", { sessionId: repository.currentRace.sessionId });
             }

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -1,7 +1,7 @@
 class Repository {
     sessions = [];
     currentRace = {
-        status: "finished",
+        status: "notStarted",
         sessionId: null,
         carNumbers: null,
         driverNames: null,
@@ -55,7 +55,7 @@ class Repository {
     loadEmptySession() {
         const oldSessionId = this.currentRace.sessionId;
         this.currentRace = {
-            status: "finished",
+            status: "notStarted",
             sessionId: null,
             carNumbers: null,
             driverNames: null,
@@ -139,11 +139,13 @@ class Repository {
         }
 
         this.currentRace = {
-           status: "finished",
+           status: "notStarted",
            sessionId: null,
            carNumbers: null,
+           driverNames: null,
            completedLaps: null,
            bestLapTime: null,
+           lastLapStartTimes: null,
            flag: "red",
            remainingSeconds: null
        };
@@ -247,11 +249,15 @@ class Repository {
         if (sessionId === this.currentRace.sessionId) {
             return;
         }
+        const trimmedDriverName = String(driverName ?? "").trim();
+        if (trimmedDriverName === "") {
+            return;
+        }
         for (let i = 0; i < this.sessions.length; i++) {
             if (this.sessions[i].sessionId === sessionId) {
                 if (!(this.sessions[i].driverNames.length >= 8)) {
                     for (let j = 0; j < this.sessions[i].driverNames.length; j++) {
-                        if (this.sessions[i].driverNames[j] === driverName) {
+                        if (this.sessions[i].driverNames[j] === trimmedDriverName) {
                             return;
                         }
                     }
@@ -264,7 +270,7 @@ class Repository {
                             }
                         }
                         if (!numberTaken) {
-                            this.sessions[i].driverNames.push(driverName);
+                            this.sessions[i].driverNames.push(trimmedDriverName);
                             this.sessions[i].carNumbers.push(carNumber);
                             return;
                         }
@@ -278,14 +284,23 @@ class Repository {
         if (sessionId === this.currentRace.sessionId) {
             return;
         }
+        const trimmedNewName = String(newName ?? "").trim();
+        if (trimmedNewName === "") {
+            return;
+        }
         for (let i = 0; i < this.sessions.length; i++) {
             if (this.sessions[i].sessionId === sessionId) {
+                const driverIndex = this.sessions[i].driverNames.indexOf(driverName);
+                if (driverIndex === -1) {
+                    return;
+                }
                 for (let j = 0; j < this.sessions[i].driverNames.length; j++) {
-                    if (this.sessions[i].driverNames[j] === driverName) {
-                        this.sessions[i].driverNames[j] = newName;
+                    if (j !== driverIndex && this.sessions[i].driverNames[j] === trimmedNewName) {
                         return;
                     }
                 }
+                this.sessions[i].driverNames[driverIndex] = trimmedNewName;
+                return;
             }
         }
     }
@@ -333,4 +348,3 @@ class Repository {
 }
 
 module.exports = Repository;
-

--- a/frontend/app/src/app/screens/next-race/next-race.ts
+++ b/frontend/app/src/app/screens/next-race/next-race.ts
@@ -25,7 +25,6 @@ export class NextRace implements OnInit, OnDestroy {
   message = 'No upcoming session available';
   nextSession: NextSessionPayload | null = null;
   showPaddockPrompt = false;
-  private hasRaceProgressed = false;
 
   ngOnInit(): void {
     this.socket = io();
@@ -50,24 +49,12 @@ export class NextRace implements OnInit, OnDestroy {
     });
 
     this.socket.on('sessionStatus', (args: { status: 'notStarted' | 'active' | 'finished' }) => {
-      if (args.status === 'active' || args.status === 'finished') {
-        this.hasRaceProgressed = true;
-      }
-
-      if (args.status === 'active') {
-        this.showPaddockPrompt = false;
-        this.cdr.detectChanges();
-        return;
-      }
-
-      if (args.status === 'notStarted' && this.hasRaceProgressed) {
-        this.showPaddockPrompt = true;
-      }
+      this.showPaddockPrompt = args.status === 'finished';
       this.cdr.detectChanges();
     });
 
     this.socket.on('sessionEnded', () => {
-      this.showPaddockPrompt = true;
+      this.showPaddockPrompt = false;
       this.cdr.detectChanges();
     });
 
@@ -75,12 +62,6 @@ export class NextRace implements OnInit, OnDestroy {
       if (this.isNextSessionPayload(data)) {
         this.nextSession = data;
         this.message = '';
-        this.showPaddockPrompt = false;
-
-        if (data.status === 'ended') {
-          this.showPaddockPrompt = true;
-        }
-
         this.cdr.detectChanges();
         return;
       }
@@ -88,9 +69,6 @@ export class NextRace implements OnInit, OnDestroy {
       if (data && typeof data === 'object' && 'message' in data) {
         this.nextSession = null;
         this.message = String((data as { message?: string }).message ?? 'No upcoming races');
-        if (this.hasRaceProgressed) {
-          this.showPaddockPrompt = true;
-        }
         this.cdr.detectChanges();
         return;
       }

--- a/frontend/app/src/app/screens/race-control/race-control.ts
+++ b/frontend/app/src/app/screens/race-control/race-control.ts
@@ -27,7 +27,7 @@ export class RaceControl implements OnInit, OnDestroy {
   private cdr = inject(ChangeDetectorRef);
 
   connected = false;
-  sessionStatus: SessionStatus = 'finished';
+  sessionStatus: SessionStatus = 'notStarted';
   currentFlag: RaceFlag | '' = '';
   message = '';
   authError = '';


### PR DESCRIPTION
Fixes several race/session state issues found during testing.

## What Was Fixed

- Prevented duplicate driver names when editing a driver
  - Driver names now remain unique within the same session.
  - Empty or whitespace-only edited names are rejected.
  - Name trimming is handled on the backend so the rule is enforced server-side.

- Fixed Race Control cold-start state
  - Initial state is now `notStarted` instead of `finished`.
  - Race Control now shows the active `Start Race` flow on first load.
  - `End Session` no longer appears on cold start.

- Removed non-editable sessions from Front Desk
  - The currently loaded/running session is filtered out of Front Desk updates.
  - Sessions that are no longer editable disappear from the editable list instead of staying visible as `Locked`.

- Fixed Next Race paddock prompt behavior
  - “Please proceed to the paddock.” now appears only while the race is in finish mode.
  - The prompt disappears when the session ends or the next race starts.
  - Upcoming race updates no longer accidentally re-enable the prompt.