### PR TITLE
Fix:  End Session button when no next race exists

### DIFF
--- a/frontend/app/src/app/screens/race-control/race-control.ts
+++ b/frontend/app/src/app/screens/race-control/race-control.ts
@@ -157,7 +157,7 @@ export class RaceControl implements OnInit, OnDestroy {
   }
 
   canEndSession(): boolean {
-    return this.connected && this.sessionStatus === 'finished' && this.nextSessionMessage === '';
+    return this.connected && this.sessionStatus === 'finished';
   }
 
   showRaceControls(): boolean {


### PR DESCRIPTION
## Summary

Fixes the Race Control **End Session** button staying disabled when the current race is finished but there are no upcoming races.

Previously, `canEndSession()` also checked whether `nextSessionMessage` was empty. When the first and only race was running, the backend correctly sent `"No upcoming races"`, which made `nextSessionMessage` non-empty and kept the button disabled.

Now the button is enabled based on the current session state only.

## Changes

- Updated Race Control end-session eligibility logic.
- Removed the dependency on upcoming race availability from `canEndSession()`.


Closes #78 
