### PR TITLE
fix: keep active race sessions visible in Front Desk for locking

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -61,7 +61,9 @@ function getEditableSessions() {
 }
 
 const timerTick = function() {
-    if (repository.currentRace.remainingSeconds < 0) {
+    if (repository.currentRace.remainingSeconds <= 0) {
+        repository.currentRace.remainingSeconds = 0;
+        io.to("leader-board").emit("timerTick", { remainingSeconds: repository.currentRace.remainingSeconds });
         repository.endRace();
         broadcastSessionStatus();
         broadcastFlagChanged();
@@ -89,7 +91,7 @@ function sessionsUpdated() {
 }
 
 function broadcastSessionStatus() {
-    let sessionStatus = repository.currentRace.status;
+    const sessionStatus = repository.currentRace.status;
     io.to("race-control").emit("sessionStatus", { status: sessionStatus });
     io.to("lap-line-tracker").emit("sessionStatus", { status: sessionStatus });
     io.to("leader-board").emit("sessionStatus", { status: sessionStatus });
@@ -210,6 +212,12 @@ io.on("connection", (socket) => {
         io.timeout(5000).to("race-countdown").emit("startCountdown", {
             duration: repository.defaultCountdownDuration
         }, (err, response) => {
+            if (err) {
+                repository.countdownInProgress = false;
+                callback({ status: "Invalid Session Status" });
+                console.log("No clients responded to startCountdown event, aborting countdown");
+                return;
+            }            
             callback({ status: "Success" })
             setTimeout(() => {
                 repository.countdownInProgress = false;
@@ -234,9 +242,12 @@ io.on("connection", (socket) => {
         if (!socket.rooms.has("race-control")) {
             return;
         }
+        if (repository.currentRace.status !== "finished") {
+            return;
+        }        
 
         if (repository.sessions.length < 2) {
-            // Load a non-functional session of id -1 into currentRace
+            // Reset current race into empty no-active-session state
             repository.loadEmptySession();
             if (repository.sessions.length === 0) {
                 // In loading session, old stale session will be deleted, so everything needs to be updated.
@@ -265,16 +276,6 @@ io.on("connection", (socket) => {
             driverNames: repository.currentRace.driverNames,
             carNumbers: repository.currentRace.carNumbers
         });
-
-        io.to("race-control")
-        .to("leader-board")
-        .to("race-flags")
-        .emit("flagChanged", { flag: repository.currentRace.flag });
-            
-        io.to("race-control")
-        .to("lap-line-tracker")
-        .to("leader-board")
-        .emit("sessionStatus", { status: repository.currentRace.status });
 
         sessionsUpdated();
 
@@ -326,7 +327,10 @@ io.on("connection", (socket) => {
         if (!socket.rooms.has("lap-line-tracker")) {
             return;
         }
-        repository.addLap(args.carNumber);
+        const status = repository.addLap(args.carNumber);
+        if (status !== "Success") {
+            return;
+        }
         io.to("leader-board").emit("lapTimes", {
             carNumbers: repository.currentRace.carNumbers,
             completedLaps: repository.currentRace.completedLaps,

--- a/backend/index.js
+++ b/backend/index.js
@@ -322,6 +322,25 @@ io.on("connection", (socket) => {
         broadcastNextSession();
     });
 
+    socket.on("driverCarEdited", (args) => {
+        if (!socket.rooms.has("front-desk")) {
+            return;
+        }
+
+        const status = repository.updateDriverCar(
+            args.sessionId,
+            args.driverName,
+            args.carNumber
+        );
+
+        if (status !== "Success") {
+            return;
+        }
+
+        sessionsUpdated();
+        broadcastNextSession();
+    });
+
     socket.on("lap", (args) => {
         if (!socket.rooms.has("lap-line-tracker")) {
             return;

--- a/backend/index.js
+++ b/backend/index.js
@@ -56,10 +56,6 @@ const repository = new Repository(raceDuration, 10);
 
 let timer = undefined;
 
-function getEditableSessions() {
-    return repository.sessions.filter((session) => session.sessionId !== repository.currentRace.sessionId);
-}
-
 const timerTick = function() {
     if (repository.currentRace.remainingSeconds <= 0) {
         repository.currentRace.remainingSeconds = 0;
@@ -87,7 +83,7 @@ if (env.NGROK_AUTHTOKEN !== "none") {
     	.then(listener => console.log(`Ingress established at: ${listener.url()}`));
 }
 function sessionsUpdated() {
-    io.to("front-desk").emit("sessionsUpdated", getEditableSessions());
+    io.to("front-desk").emit("sessionsUpdated", repository.sessions);
 }
 
 function broadcastSessionStatus() {

--- a/backend/index.js
+++ b/backend/index.js
@@ -83,7 +83,10 @@ if (env.NGROK_AUTHTOKEN !== "none") {
     	.then(listener => console.log(`Ingress established at: ${listener.url()}`));
 }
 function sessionsUpdated() {
-    io.to("front-desk").emit("sessionsUpdated", repository.sessions);
+    const sessions = repository.sessions.filter(
+        (s) => s.sessionId !== repository.currentRace.sessionId
+    );
+    io.to("front-desk").emit("sessionsUpdated", sessions);
 }
 
 function broadcastSessionStatus() {

--- a/backend/on_connection.js
+++ b/backend/on_connection.js
@@ -43,7 +43,12 @@ module.exports = function onConnection (socket, repository, room) {
             socket.emit("flagChanged", { flag: repository.currentRace.flag });
             break;
         case "front-desk":
-            socket.emit("sessionsUpdated", repository.sessions);
+            socket.emit(
+                "sessionsUpdated",
+                repository.sessions.filter(
+                    (s) => s.sessionId !== repository.currentRace.sessionId
+                )
+            );
             if (repository.currentRace.sessionId !== null) {
                 socket.emit("sessionStarted", { sessionId: repository.currentRace.sessionId });
             }

--- a/backend/on_connection.js
+++ b/backend/on_connection.js
@@ -43,10 +43,7 @@ module.exports = function onConnection (socket, repository, room) {
             socket.emit("flagChanged", { flag: repository.currentRace.flag });
             break;
         case "front-desk":
-            socket.emit(
-                "sessionsUpdated",
-                repository.sessions.filter((session) => session.sessionId !== repository.currentRace.sessionId)
-            );
+            socket.emit("sessionsUpdated", repository.sessions);
             if (repository.currentRace.sessionId !== null) {
                 socket.emit("sessionStarted", { sessionId: repository.currentRace.sessionId });
             }

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -313,6 +313,37 @@ class Repository {
         }
     }
 
+    updateDriverCar(sessionId, driverName, newCarNumber) {
+        if (sessionId === this.currentRace.sessionId) {
+            return "Session locked";
+        }
+
+        const parsedCarNumber = Number(newCarNumber);
+        if (!Number.isInteger(parsedCarNumber) || parsedCarNumber < 1 || parsedCarNumber > 8) {
+            return "Invalid car number";
+        }
+
+        for (let i = 0; i < this.sessions.length; i++) {
+            if (this.sessions[i].sessionId === sessionId) {
+                const driverIndex = this.sessions[i].driverNames.indexOf(driverName);
+                if (driverIndex === -1) {
+                    return "Driver not found";
+                }
+
+                for (let j = 0; j < this.sessions[i].carNumbers.length; j++) {
+                    if (j !== driverIndex && this.sessions[i].carNumbers[j] === parsedCarNumber) {
+                        return "Car already taken";
+                    }
+                }
+
+                this.sessions[i].carNumbers[driverIndex] = parsedCarNumber;
+                return "Success";
+            }
+        }
+
+        return "Session not found";
+    }
+
     deleteDriver(sessionId, driverName) {
         if (sessionId === this.currentRace.sessionId) {
             return;

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -265,7 +265,7 @@ class Repository {
             if (this.sessions[i].sessionId === sessionId) {
                 if (!(this.sessions[i].driverNames.length >= 8)) {
                     for (let j = 0; j < this.sessions[i].driverNames.length; j++) {
-                        if (this.sessions[i].driverNames[j] === trimmedDriverName) {
+                        if (this.sessions[i].driverNames[j].toLowerCase() === trimmedDriverName.toLowerCase()) {
                             return;
                         }
                     }
@@ -303,7 +303,7 @@ class Repository {
                     return;
                 }
                 for (let j = 0; j < this.sessions[i].driverNames.length; j++) {
-                    if (j !== driverIndex && this.sessions[i].driverNames[j] === trimmedNewName) {
+                    if (j !== driverIndex && this.sessions[i].driverNames[j].toLowerCase() === trimmedNewName.toLowerCase()) {
                         return;
                     }
                 }

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -195,8 +195,16 @@ class Repository {
         return "Success";
     }
     endRace() {
+        if (this.currentRace.sessionId === null) {
+            return "No session loaded";
+        }
+        if (this.currentRace.status !== "active") {
+            return "Race not Active";
+        }        
         this.currentRace.status = "finished";
         this.currentRace.flag = "finish";
+        this.countdownInProgress = false;
+        return "Success";        
     }
     beginStartCountdown() {
         if (this.currentRace.sessionId === null) {
@@ -323,12 +331,24 @@ class Repository {
     }
 
     addLap(carNumber) {
+
+        if (this.currentRace.status !== "active") {
+            return "Race not Active";
+        }
+
+        if (!Array.isArray(this.currentRace.carNumbers) ||
+            !Array.isArray(this.currentRace.completedLaps) ||
+            !Array.isArray(this.currentRace.bestLapTime) ||
+            !Array.isArray(this.currentRace.lastLapStartTimes)) {
+            return "No session loaded";
+        }        
+
         for (let i = 0; i < this.currentRace.carNumbers.length; i++) {
             if (this.currentRace.carNumbers[i] === carNumber) {
                 if (this.currentRace.completedLaps[i] === 0) {
                     this.currentRace.completedLaps[i] = 1;
                     this.currentRace.lastLapStartTimes[i] = Date.now();
-                    return;
+                    return "Success";
                 }
                 this.currentRace.completedLaps[i]++;
                 const lapTimeStamp = Date.now();
@@ -340,8 +360,10 @@ class Repository {
                 else if (this.currentRace.bestLapTime[i] > lapTime) {
                     this.currentRace.bestLapTime[i] = lapTime;
                 }
+                return "Success";
             }
         } 
+        return "Car not found";
     }
 
      // addSession, updateSession, addDriver, updateDriver, deleteDriver, etc have to be implemented

--- a/frontend/app/src/app/screens/front-desk/front-desk.html
+++ b/frontend/app/src/app/screens/front-desk/front-desk.html
@@ -102,7 +102,6 @@
                   [ngModel]="session.carNumbers[i]"
                   (ngModelChange)="changeDriverCar(session.sessionId, driverName, $event)"
                   [attr.aria-label]="'Assign car for ' + driverName"
-                  [disabled]="true"
                 >
                   <option
                     *ngFor="let car of carOptions"


### PR DESCRIPTION
Fixes issue where active session was removed from Front Desk.

Removed filtering logic so all sessions are sent.
Enforce case-insensitive uniqueness for driver names to prevent duplicates like "John" and "john".
Frontend can now show active session as locked.

Covers:
- Front Desk session visibility issue
- Driver name duplication (case-insensitive)
