### PR TITLE
fix(be): sync front-desk after last session end

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -259,6 +259,7 @@ io.on("connection", (socket) => {
                 broadcastFlagChanged();
                 broadcastSessionStatus();
                 broadcastNextSession();
+                sessionsUpdated();
                 return;
             }
         }
@@ -287,8 +288,6 @@ io.on("connection", (socket) => {
             completedLaps: repository.currentRace.completedLaps,
             bestLapTime: repository.currentRace.bestLapTime
         });
-
-        sessionsUpdated();
 
         io.to("front-desk").emit("sessionStarted", { sessionId: repository.currentRace.sessionId });
     });


### PR DESCRIPTION
Fixes front-desk state inconsistency after last session ends.

- ensure sessionsUpdated() is emitted before early return
- remove duplicate emit to avoid redundant updates