### PR TITLE
feat(be): implement state persistence and restart recovery

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -259,6 +259,7 @@ io.on("connection", (socket) => {
                 broadcastFlagChanged();
                 broadcastSessionStatus();
                 broadcastNextSession();
+                sessionsUpdated();
                 return;
             }
         }
@@ -287,8 +288,6 @@ io.on("connection", (socket) => {
             completedLaps: repository.currentRace.completedLaps,
             bestLapTime: repository.currentRace.bestLapTime
         });
-
-        sessionsUpdated();
 
         io.to("front-desk").emit("sessionStarted", { sessionId: repository.currentRace.sessionId });
     });

--- a/backend/index.js
+++ b/backend/index.js
@@ -61,6 +61,7 @@ const timerTick = function() {
         repository.currentRace.remainingSeconds = 0;
         io.to("leader-board").emit("timerTick", { remainingSeconds: repository.currentRace.remainingSeconds });
         repository.endRace();
+        repository.saveState();
         broadcastSessionStatus();
         broadcastFlagChanged();
         clearInterval(timer);
@@ -69,6 +70,99 @@ const timerTick = function() {
     else {
         io.to("leader-board").emit("timerTick", { remainingSeconds: repository.currentRace.remainingSeconds });
         repository.currentRace.remainingSeconds--;
+        repository.saveState();
+    }
+}
+
+recoverRaceState();
+
+// push restored state to clients
+setTimeout(() => {
+    broadcastSessionStatus();
+    broadcastFlagChanged();
+
+    if (repository.currentRace.remainingSeconds !== null) {
+        io.to("leader-board").emit("timerTick", {
+            remainingSeconds: repository.currentRace.remainingSeconds
+        });
+    }
+}, 100);
+
+function startRaceTimer() {
+    clearInterval(timer);
+    timer = setInterval(timerTick, 1000);
+}
+
+function recoverRaceState() {
+    if (repository.currentRace.status === "active" && repository.raceEndsAt !== null) {
+        const remainingSeconds = Math.max(
+            0,
+            Math.ceil((repository.raceEndsAt - Date.now()) / 1000)
+        );
+
+        repository.currentRace.remainingSeconds = remainingSeconds;
+
+        if (remainingSeconds <= 0) {
+            repository.endRace();
+            repository.saveState();
+        } else {
+            startRaceTimer();
+        }
+    }
+
+    if (repository.countdownInProgress && repository.countdownEndsAt !== null) {
+        const countdownRemainingSeconds = Math.max(
+            0,
+            Math.ceil((repository.countdownEndsAt - Date.now()) / 1000)
+        );
+
+        if (countdownRemainingSeconds <= 0) {
+            repository.startRace();
+            broadcastFlagChanged();
+            broadcastSessionStatus();
+            broadcastNextSession();
+
+            io.to("leader-board").to("lap-line-tracker").emit("sessionUpdate", {
+                sessionId: repository.currentRace.sessionId,
+                driverNames: repository.currentRace.driverNames,
+                carNumbers: repository.currentRace.carNumbers
+            });
+
+            io.to("leader-board").emit("lapTimes", {
+                carNumbers: repository.currentRace.carNumbers,
+                completedLaps: repository.currentRace.completedLaps,
+                bestLapTime: repository.currentRace.bestLapTime
+            });            
+            startRaceTimer();
+        } else {
+            io.to("race-countdown").emit("startCountdown", {
+                duration: countdownRemainingSeconds
+            });            
+            setTimeout(() => {
+                if (!repository.countdownInProgress) return;
+                
+                repository.countdownInProgress = false;
+                repository.startRace();
+
+                broadcastFlagChanged();
+                broadcastSessionStatus();
+                broadcastNextSession();
+
+                io.to("leader-board").to("lap-line-tracker").emit("sessionUpdate", {
+                    sessionId: repository.currentRace.sessionId,
+                    driverNames: repository.currentRace.driverNames,
+                    carNumbers: repository.currentRace.carNumbers
+                });
+
+                io.to("leader-board").emit("lapTimes", {
+                    carNumbers: repository.currentRace.carNumbers,
+                    completedLaps: repository.currentRace.completedLaps,
+                    bestLapTime: repository.currentRace.bestLapTime
+                });
+
+                startRaceTimer();
+            }, countdownRemainingSeconds * 1000);            
+        }
     }
 }
 
@@ -176,6 +270,7 @@ io.on("connection", (socket) => {
             repository.endRace();
             broadcastSessionStatus();
             repository.currentRace.remainingSeconds = 0;
+            repository.saveState();
             io.to("leader-board").emit("timerTick", { remainingSeconds: repository.currentRace.remainingSeconds });
         }
     });
@@ -213,6 +308,8 @@ io.on("connection", (socket) => {
         }, (err, response) => {
             if (err) {
                 repository.countdownInProgress = false;
+                repository.countdownEndsAt = null;
+                repository.saveState();                
                 callback({ status: "Invalid Session Status" });
                 console.log("No clients responded to startCountdown event, aborting countdown");
                 return;
@@ -238,8 +335,7 @@ io.on("connection", (socket) => {
                     bestLapTime: repository.currentRace.bestLapTime
                 });
 
-                clearInterval(timer);
-                timer = setInterval(timerTick, 1000);
+                startRaceTimer();
             }, repository.defaultCountdownDuration * 1000)
         });
     });

--- a/backend/repository.js
+++ b/backend/repository.js
@@ -1,3 +1,4 @@
+const { readState, writeState } = require("./state_store");
 class Repository {
     sessions = [];
     currentRace = {
@@ -15,9 +16,18 @@ class Repository {
     defaultCountdownDuration = null;
     countdownInProgress = false;
     lastSessionId = -1;
+    raceEndsAt = null;
+    countdownEndsAt = null;    
     constructor(defaultRaceDuration, defaultCountdownDuration) {
         this.defaultRaceDuration = defaultRaceDuration;
         this.defaultCountdownDuration = defaultCountdownDuration;
+        const state = readState();
+        this.sessions = state.sessions;
+        this.currentRace = state.currentRace;
+        this.lastSessionId = state.lastSessionId;
+        this.countdownInProgress = state.countdownInProgress;
+        this.raceEndsAt = state.raceEndsAt;
+        this.countdownEndsAt = state.countdownEndsAt;        
     }
     loadSession(sessionId) {
         const oldSessionId = this.currentRace.sessionId;
@@ -33,6 +43,8 @@ class Repository {
                 this.currentRace.status = "notStarted";
                 this.currentRace.flag = "red";
                 this.countdownInProgress = false;
+                this.raceEndsAt = null;
+                this.countdownEndsAt = null;                
                 for (let i = 0; i < session.carNumbers.length; i++) {
                     this.currentRace.completedLaps.push(0);
                     this.currentRace.bestLapTime.push(0);
@@ -46,6 +58,7 @@ class Repository {
                         }
                     }
                 }
+                this.saveState();
                 return "Success";
             }
         }
@@ -65,6 +78,9 @@ class Repository {
             flag: "red",
             remainingSeconds: null
         };
+        this.countdownInProgress = false;
+        this.raceEndsAt = null;
+        this.countdownEndsAt = null;        
         if (oldSessionId !== null) {
             for (let i = 0; i < this.sessions.length; i++) {
                 if (this.sessions[i].sessionId === oldSessionId) {
@@ -73,6 +89,7 @@ class Repository {
                 }
             }
         }
+        this.saveState();
         return "Success";
     }
 
@@ -94,10 +111,14 @@ class Repository {
         this.currentRace.status = "active";
         this.currentRace.flag = "green";
         this.currentRace.remainingSeconds = this.defaultRaceDuration;
+        this.countdownInProgress = false;
+        this.countdownEndsAt = null;
+        this.raceEndsAt = Date.now() + this.defaultRaceDuration * 1000;        
         const raceStartTimestamp = 0;
         for (let i = 0; i < this.currentRace.lastLapStartTimes.length; i++) {
             this.currentRace.lastLapStartTimes[i] = raceStartTimestamp;
         }
+        this.saveState();
         return {
             status: "Success",
             race: this.currentRace
@@ -122,7 +143,10 @@ class Repository {
         this.currentRace.status = "finished";
         this.currentRace.flag = "finish";
         this.countdownInProgress = false;
-
+        this.raceEndsAt = null;
+        this.countdownEndsAt = null;
+ 
+        this.saveState();
         return {
             status: "Success",
             race: this.currentRace
@@ -150,7 +174,10 @@ class Repository {
            remainingSeconds: null
        };
        this.countdownInProgress = false;
-
+       this.raceEndsAt = null;
+       this.countdownEndsAt = null;
+ 
+       this.saveState();
        return {
            status: "Success",
            race: this.currentRace
@@ -192,6 +219,7 @@ class Repository {
 
         this.currentRace.flag = flag;
 
+        this.saveState();
         return "Success";
     }
     endRace() {
@@ -204,6 +232,9 @@ class Repository {
         this.currentRace.status = "finished";
         this.currentRace.flag = "finish";
         this.countdownInProgress = false;
+        this.raceEndsAt = null;
+        this.countdownEndsAt = null;
+        this.saveState();        
         return "Success";        
     }
     beginStartCountdown() {
@@ -217,6 +248,8 @@ class Repository {
             return "Countdown in Progress"
         }
         this.countdownInProgress = true;
+        this.countdownEndsAt = Date.now() + this.defaultCountdownDuration * 1000;
+        this.saveState();
 
         return "Success";
     }
@@ -228,6 +261,7 @@ class Repository {
             carNumbers: carNumbers
         });
         this.lastSessionId++;
+        this.saveState();
     }
 
     updateSession(sessionId, driverNames, carNumbers) {
@@ -238,6 +272,7 @@ class Repository {
             if (this.sessions[i].sessionId === sessionId) {
                 this.sessions[i].driverNames = driverNames;
                 this.sessions[i].carNumbers = carNumbers;
+                this.saveState();
             }
         }
     }
@@ -249,6 +284,8 @@ class Repository {
         for (let i = 0; i < this.sessions.length; i++) {
             if (this.sessions[i].sessionId === sessionId) {
                 this.sessions.splice(i, 1);
+                this.saveState();
+                return;                
             }
         }
     }
@@ -280,6 +317,7 @@ class Repository {
                         if (!numberTaken) {
                             this.sessions[i].driverNames.push(trimmedDriverName);
                             this.sessions[i].carNumbers.push(carNumber);
+                            this.saveState();
                             return;
                         }
                     }
@@ -308,6 +346,7 @@ class Repository {
                     }
                 }
                 this.sessions[i].driverNames[driverIndex] = trimmedNewName;
+                this.saveState();
                 return;
             }
         }
@@ -337,6 +376,7 @@ class Repository {
                 }
 
                 this.sessions[i].carNumbers[driverIndex] = parsedCarNumber;
+                this.saveState();
                 return "Success";
             }
         }
@@ -354,6 +394,8 @@ class Repository {
                     if (this.sessions[i].driverNames[j] === driverName) {
                         this.sessions[i].driverNames.splice(j, 1);
                         this.sessions[i].carNumbers.splice(j, 1);
+                        this.saveState();
+                        return;                        
                     }
                 }
             }
@@ -379,6 +421,7 @@ class Repository {
                 if (this.currentRace.completedLaps[i] === 0) {
                     this.currentRace.completedLaps[i] = 1;
                     this.currentRace.lastLapStartTimes[i] = Date.now();
+                    this.saveState();
                     return "Success";
                 }
                 this.currentRace.completedLaps[i]++;
@@ -391,12 +434,23 @@ class Repository {
                 else if (this.currentRace.bestLapTime[i] > lapTime) {
                     this.currentRace.bestLapTime[i] = lapTime;
                 }
+                this.saveState();
                 return "Success";
             }
         } 
         return "Car not found";
     }
 
+    saveState() {
+        writeState({
+            sessions: this.sessions,
+            currentRace: this.currentRace,
+            lastSessionId: this.lastSessionId,
+            countdownInProgress: this.countdownInProgress,
+            raceEndsAt: this.raceEndsAt,
+            countdownEndsAt: this.countdownEndsAt
+        });
+    }
      // addSession, updateSession, addDriver, updateDriver, deleteDriver, etc have to be implemented
 }
 

--- a/backend/state_store.js
+++ b/backend/state_store.js
@@ -1,0 +1,73 @@
+const fs = require("fs");
+const path = require("path");
+
+const STATE_FILE_PATH = path.join(__dirname, "state.json");
+
+const DEFAULT_STATE = {
+    sessions: [],
+    currentRace: {
+        status: "notStarted",
+        sessionId: null,
+        carNumbers: null,
+        driverNames: null,
+        completedLaps: null,
+        bestLapTime: null,
+        lastLapStartTimes: null,
+        flag: "red",
+        remainingSeconds: null
+    },
+    lastSessionId: -1,
+    countdownInProgress: false,
+    raceEndsAt: null,
+    countdownEndsAt: null
+};
+
+function cloneDefaultState() {
+    return JSON.parse(JSON.stringify(DEFAULT_STATE));
+}
+
+function readState() {
+    try {
+        if (!fs.existsSync(STATE_FILE_PATH)) {
+            return cloneDefaultState();
+        }
+
+        const raw = fs.readFileSync(STATE_FILE_PATH, "utf8");
+        if (!raw.trim()) {
+            return cloneDefaultState();
+        }
+
+        const parsed = JSON.parse(raw);
+
+        return {
+            ...cloneDefaultState(),
+            ...parsed,
+            currentRace: {
+                ...cloneDefaultState().currentRace,
+                ...(parsed.currentRace || {})
+            }
+        };
+    } catch (error) {
+        console.error("Failed to read state.json, using default state.", error);
+        return cloneDefaultState();
+    }
+}
+
+function writeState(state) {
+    try {
+        fs.writeFileSync(
+            STATE_FILE_PATH,
+            JSON.stringify(state, null, 2),
+            "utf8"
+        );
+    } catch (error) {
+        console.error("Failed to write state.json.", error);
+    }
+}
+
+module.exports = {
+    readState,
+    writeState,
+    STATE_FILE_PATH,
+    DEFAULT_STATE
+};


### PR DESCRIPTION
Implements persistent system state and automatic recovery on server restart.

- Added file-based state storage (state_store.js)
- Integrated save/load logic into repository
- Added race and countdown timestamps (raceEndsAt, countdownEndsAt)
- Implemented recovery logic on server startup

Behavior:
- Active race resumes with correct remaining time after restart
- Countdown resumes or completes correctly after restart
- Sessions are preserved and not lost

Key changes:
- index.js: recovery flow and timer restart handling
- repository.js: persistence hooks and timestamps
- state_store.js: read/write state to file

Tested:
- Restart during active race: timer continues
- Restart during countdown: countdown resumes
- Restart idle: state restored correctly
- Sessions persist across restart

Closes #85