### PR TITLE
fix(fe): rank leaderboard by laps with best-lap tie-break

### DIFF
--- a/frontend/app/src/app/screens/leader-board/leader-board.html
+++ b/frontend/app/src/app/screens/leader-board/leader-board.html
@@ -3,7 +3,7 @@
     <div class="header-row">
       <div>
         <h1>Leaderboard</h1>
-        <p class="screen-subtitle">Live race ranking and best laps.</p>
+        <p class="screen-subtitle">Ranking by laps, tie-break by best lap.</p>
       </div>
       <button class="btn btn-primary" (click)="enterFullscreen()">Full Screen</button>
     </div>

--- a/frontend/app/src/app/screens/leader-board/leader-board.ts
+++ b/frontend/app/src/app/screens/leader-board/leader-board.ts
@@ -37,10 +37,18 @@ export class LeaderBoard implements OnInit, OnDestroy {
 
   get sortedEntries(): LeaderboardEntry[] {
     return [...this.entries].sort((a, b) => {
-      if (a.bestLapTime === 0 && b.bestLapTime === 0) return 0;
+      if (a.completedLaps !== b.completedLaps) {
+        return b.completedLaps - a.completedLaps;
+      }
+      if (a.bestLapTime === 0 && b.bestLapTime === 0) {
+        return a.carNumber - b.carNumber;
+      }
       if (a.bestLapTime === 0) return 1;
       if (b.bestLapTime === 0) return -1;
-      return a.bestLapTime - b.bestLapTime;
+      if (a.bestLapTime !== b.bestLapTime) {
+        return a.bestLapTime - b.bestLapTime;
+      }
+      return a.carNumber - b.carNumber;
     });
   }
 


### PR DESCRIPTION
Fixes #91

Update leaderboard sorting so race position is ranked by completed laps first, with best lap time used as the tie-breaker.

Also updates the leaderboard subtitle to reflect the ranking logic.