### PR TITLE
Fix (frontend): Fix paddock message timing

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -142,3 +142,6 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .vite/
+
+# Project-specific files
+state.json

--- a/frontend/app/src/app/screens/next-race/next-race.ts
+++ b/frontend/app/src/app/screens/next-race/next-race.ts
@@ -49,12 +49,11 @@ export class NextRace implements OnInit, OnDestroy {
     });
 
     this.socket.on('sessionStatus', (args: { status: 'notStarted' | 'active' | 'finished' }) => {
-      this.showPaddockPrompt = args.status === 'finished';
+      this.showPaddockPrompt = args.status === 'notStarted';
       this.cdr.detectChanges();
     });
 
     this.socket.on('sessionEnded', () => {
-      this.showPaddockPrompt = false;
       this.cdr.detectChanges();
     });
 


### PR DESCRIPTION
Fix paddock message timing to be after end session and to disappear when race starts, so, when sessionStatus is notStarted.

Minor change, also added state persistence file to .gitignore