### PR TITLE
feat: show race flag as color on leaderboard

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -193,7 +193,8 @@ function broadcastSessionStatus() {
 
 function broadcastFlagChanged() {
     const flag = repository.currentRace.flag;
-
+    
+    io.to("lap-line-tracker").emit("flagChanged", { flag: flag });
     io.to("race-control").emit("flagChanged", { flag: flag });
     io.to("leader-board").emit("flagChanged", { flag: flag });
     io.to("race-flags").emit("flagChanged", { flag: flag });

--- a/backend/on_connection.js
+++ b/backend/on_connection.js
@@ -72,6 +72,7 @@ module.exports = function onConnection (socket, repository, room) {
             }
             break;
         case "lap-line-tracker":
+            socket.emit("flagChanged", { flag: repository.currentRace.flag });
             socket.emit("sessionStatus", { status: status });
             socket.emit("sessionUpdate", {
                 sessionId: repository.currentRace.sessionId,

--- a/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.html
+++ b/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.html
@@ -48,7 +48,11 @@
         </button>
       </div>
 
-      <p *ngIf="!canRecordLaps" class="muted">
+      <p *ngIf="!canRecordLaps && currentFlag === 'red' && sessionStatus !== 'notStarted'" class="muted">
+        Lap buttons are disabled during Danger mode to prevent wrong inputs.
+      </p>
+
+      <p *ngIf="!canRecordLaps && (sessionStatus === 'notStarted')" class="muted">
         Lap buttons are disabled until race status is active or finished.
       </p>
 

--- a/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.ts
+++ b/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.ts
@@ -19,6 +19,7 @@ type SessionUpdatePayload = {
   styleUrl: './lap-line-tracker.scss',
 })
 export class LapLineTracker implements OnInit, OnDestroy {
+  currentFlag: string = 'red';
   private socket!: Socket;
   private pendingLogin = false;
   private loginTimeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -43,6 +44,11 @@ export class LapLineTracker implements OnInit, OnDestroy {
       reconnectionAttempts: 5,
       reconnectionDelay: 1000,
       timeout: 5000
+    });
+
+    this.socket.on('flagChanged', (args: { flag: string }) => {
+      this.currentFlag = args.flag;
+      this.cdr.detectChanges();
     });
 
     this.socket.on('connect', () => {
@@ -143,7 +149,7 @@ export class LapLineTracker implements OnInit, OnDestroy {
   }
 
   get canRecordLaps(): boolean {
-    return this.isAuthenticated && this.isConnected && this.sessionStatus !== 'notStarted';
+    return this.isAuthenticated && this.isConnected && this.sessionStatus !== 'notStarted' && this.currentFlag !== 'red';
   }
 
   trackByCarNumber(_index: number, carNumber: number): number {

--- a/frontend/app/src/app/screens/leader-board/leader-board.html
+++ b/frontend/app/src/app/screens/leader-board/leader-board.html
@@ -12,7 +12,11 @@
 
     <div class="status-grid">
       <p class="status-chip"><strong>Time:</strong> {{ formatTime(remainingSeconds) }}</p>
-      <p class="status-chip"><strong>Flag:</strong> {{ currentFlag ?? 'none' }}</p>
+      <p class="status-chip">
+        <strong>Flag:</strong>
+        <span class="flag-indicator" [class]="'flag-indicator flag-' + (currentFlag ?? 'none')"></span>
+        {{ currentFlag ?? 'none' }}
+      </p>
       <p class="status-chip"><strong>Status:</strong> {{ sessionStatus }}</p>
     </div>
 

--- a/frontend/app/src/app/screens/leader-board/leader-board.scss
+++ b/frontend/app/src/app/screens/leader-board/leader-board.scss
@@ -16,6 +16,31 @@
 	font-weight: 600;
 }
 
+.flag-indicator {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  margin: 0 6px;
+  background: gray;
+}
+
+.flag-green {
+  background: #22c55e;
+}
+
+.flag-yellow {
+  background: #eab308;
+}
+
+.flag-red {
+  background: #ef4444;
+}
+
+.flag-finish {
+  background: #3b82f6;
+}
+
 @media (max-width: 720px) {
 	.header-row {
 		flex-direction: column;

--- a/frontend/app/src/app/screens/race-countdown/race-countdown.html
+++ b/frontend/app/src/app/screens/race-countdown/race-countdown.html
@@ -10,7 +10,8 @@
 
     <div class="countdown-display">
       <ng-container *ngIf="countdown !== null; else idleState">
-        <h2 class="countdown-value">{{ countdown }}</h2>
+        <p class="countdown-label">Race starts in</p>
+        <h2 class="countdown-value">{{ countdown }}s</h2>
       </ng-container>
 
       <ng-template #idleState>


### PR DESCRIPTION
Improves UX by displaying race flag as a color indicator instead of relying on text.

- Adds visual flag indicator (red, yellow, green, finish)
- Keeps text as secondary information
- Improves quick recognition of race state

Closes #98