### PR TITLE
feat: finalize UX polish across private screens and leaderboard

### DIFF
--- a/frontend/app/src/app/app.scss
+++ b/frontend/app/src/app/app.scss
@@ -13,7 +13,7 @@
 	top: 0;
 	z-index: 25;
 	display: grid;
-	grid-template-columns: 1fr minmax(220px, 340px) 1fr;
+	grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 	align-items: center;
 	gap: 0.85rem;
 	padding: 0.85rem 1rem;
@@ -45,14 +45,24 @@
 	flex-wrap: wrap;
 	align-items: center;
 	gap: 0.5rem;
+	min-width: 0;
 }
 
 .nav-left {
 	justify-content: flex-start;
+	overflow-x: auto;
+	scrollbar-width: none;
 }
 
 .nav-right {
 	justify-content: flex-end;
+	overflow-x: auto;
+	scrollbar-width: none;
+}
+
+.nav-left::-webkit-scrollbar,
+.nav-right::-webkit-scrollbar {
+	display: none;
 }
 
 .nav-link,
@@ -82,6 +92,8 @@
 	background: linear-gradient(135deg, #f7c32e 0%, #f6e07f 100%);
 	font-size: 1rem;
 	text-align: center;
+	white-space: nowrap;
+	min-width: 260px;
 }
 
 .nav-link:hover,

--- a/frontend/app/src/app/screens/front-desk/front-desk.ts
+++ b/frontend/app/src/app/screens/front-desk/front-desk.ts
@@ -12,7 +12,7 @@ interface Session {
   sessionId: number;
   driverNames: string[];
   carNumbers: number[];
-  locked?: boolean; 
+  locked?: boolean;
 }
 
 @Component({
@@ -29,6 +29,7 @@ export class FrontDeskComponent implements OnInit, OnDestroy {
   private loginTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private readonly lockedSessionIds = new Set<number>();
   private cdr = inject(ChangeDetectorRef);
+  private readonly storageKey = 'front-desk-access-key';
 
   sessions: Session[] = [];
   accessKey: string = '';
@@ -42,7 +43,12 @@ export class FrontDeskComponent implements OnInit, OnDestroy {
   readonly carOptions: number[] = [1, 2, 3, 4, 5, 6, 7, 8];
 
   ngOnInit(): void {
+    this.accessKey = localStorage.getItem(this.storageKey) ?? '';
     this.initSocket();
+
+    if (this.accessKey) {
+      this.login();
+    }
   }
 
   ngOnDestroy(): void {
@@ -105,7 +111,13 @@ export class FrontDeskComponent implements OnInit, OnDestroy {
   }
 
   login(): void {
+
+    const trimmedAccessKey = this.accessKey.trim();
+
     if (!this.accessKey.trim() || this.isConnecting) return;
+
+    this.accessKey = trimmedAccessKey;
+    localStorage.setItem(this.storageKey, this.accessKey);
 
     this.isConnecting = true;
     this.authError = '';

--- a/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.ts
+++ b/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.ts
@@ -24,6 +24,7 @@ export class LapLineTracker implements OnInit, OnDestroy {
   private pendingLogin = false;
   private loginTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private cdr = inject(ChangeDetectorRef);
+  private readonly storageKey = 'lap-line-tracker-access-key';
 
   carNumbers: number[] = [];
 
@@ -38,6 +39,8 @@ export class LapLineTracker implements OnInit, OnDestroy {
   private hasRaceProgressed = false;
 
   ngOnInit(): void {
+    this.accessKey = localStorage.getItem(this.storageKey) ?? '';
+
     this.socket = io({
       autoConnect: false,
       reconnection: true,
@@ -122,9 +125,15 @@ export class LapLineTracker implements OnInit, OnDestroy {
   }
 
   connect(): void {
+
+    const trimmedAccessKey = this.accessKey.trim();
+
     if (!this.accessKey.trim() || this.isConnecting) {
       return;
     }
+
+    this.accessKey = trimmedAccessKey;
+    localStorage.setItem(this.storageKey, this.accessKey);
 
     this.isConnecting = true;
     this.authError = '';

--- a/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.ts
+++ b/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.ts
@@ -57,10 +57,12 @@ export class LapLineTracker implements OnInit, OnDestroy {
     this.socket.on('connect', () => {
       this.isConnected = true;
 
-      if (this.pendingLogin) {
+      if (this.pendingLogin || (this.accessKey && !this.isAuthenticated)) {
         this.pendingLogin = false;
         this.joinLapLineRoom();
       }
+
+      this.cdr.detectChanges();
     });
 
     this.socket.on('disconnect', () => {
@@ -118,7 +120,12 @@ export class LapLineTracker implements OnInit, OnDestroy {
     });
 
     if (this.accessKey) {
-      this.connect();
+      this.pendingLogin = true;
+      this.isConnecting = true;
+      this.authError = '';
+      this.statusMessage = 'Connecting...';
+      this.startLoginTimeout();
+      this.socket.connect();
     }
   }
 
@@ -130,10 +137,9 @@ export class LapLineTracker implements OnInit, OnDestroy {
   }
 
   connect(): void {
-
     const trimmedAccessKey = this.accessKey.trim();
 
-    if (!this.accessKey.trim() || this.isConnecting) {
+    if (!trimmedAccessKey || this.isConnecting) {
       return;
     }
 
@@ -146,6 +152,7 @@ export class LapLineTracker implements OnInit, OnDestroy {
     this.startLoginTimeout();
 
     if (this.socket.connected) {
+      this.pendingLogin = false;
       this.joinLapLineRoom();
       return;
     }

--- a/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.ts
+++ b/frontend/app/src/app/screens/lap-line-tracker/lap-line-tracker.ts
@@ -55,9 +55,10 @@ export class LapLineTracker implements OnInit, OnDestroy {
     });
 
     this.socket.on('connect', () => {
-      if (this.pendingLogin || this.isAuthenticated) {
+      this.isConnected = true;
+
+      if (this.pendingLogin) {
         this.pendingLogin = false;
-        this.isConnected = true;
         this.joinLapLineRoom();
       }
     });
@@ -115,6 +116,10 @@ export class LapLineTracker implements OnInit, OnDestroy {
       this.applyCarNumbers(args.carNumbers);
       this.cdr.detectChanges();
     });
+
+    if (this.accessKey) {
+      this.connect();
+    }
   }
 
   ngOnDestroy(): void {

--- a/frontend/app/src/app/screens/leader-board/leader-board.scss
+++ b/frontend/app/src/app/screens/leader-board/leader-board.scss
@@ -38,7 +38,8 @@
 }
 
 .flag-finish {
-  background: #3b82f6;
+  background: #ffffff;
+  border: 2px solid rgba(0, 0, 0, 0.4);
 }
 
 @media (max-width: 720px) {

--- a/frontend/app/src/app/screens/race-control/race-control.ts
+++ b/frontend/app/src/app/screens/race-control/race-control.ts
@@ -25,6 +25,7 @@ export class RaceControl implements OnInit, OnDestroy {
   private pendingLogin = false;
   private loginTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private cdr = inject(ChangeDetectorRef);
+  private readonly storageKey = 'race-control-access-key';
 
   connected = false;
   sessionStatus: SessionStatus = 'notStarted';
@@ -37,6 +38,8 @@ export class RaceControl implements OnInit, OnDestroy {
   accessKey = '';
 
   ngOnInit(): void {
+    this.accessKey = localStorage.getItem(this.storageKey) ?? '';
+
     this.socket = io({
       autoConnect: false,
       reconnection: true,
@@ -96,12 +99,22 @@ export class RaceControl implements OnInit, OnDestroy {
         this.cdr.detectChanges();
       }
     });
+
+    if (this.accessKey) {
+      this.connect();
+    }
   }
 
   connect(): void {
+
+    const trimmedAccessKey = this.accessKey.trim();
+
     if (!this.accessKey.trim() || this.isConnecting) {
       return;
     }
+
+    this.accessKey = trimmedAccessKey;
+    localStorage.setItem(this.storageKey, this.accessKey);
 
     this.isConnecting = true;
     this.authError = '';


### PR DESCRIPTION
Final UX improvements based on review feedback:

- Fix header navigation layout and overflow handling
- Persist access keys in browser for private screens
- Add auto-connect using saved access keys (Front Desk, Race Control, Lap-line Tracker)
- Improve finish flag visibility on leaderboard (replace blue with white)

Focus is on UX only. No backend logic changes.

Closes:
#102 